### PR TITLE
Add GitHub maintenance and security baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report a reproducible Buddy2api problem
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Never upload Work Buddy or CodeBuddy credentials, access or refresh tokens, generated API keys, account databases, or unredacted request logs. Replace them with synthetic values.
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      placeholder: "For example: v1.0.0 or abc1234"
+    validations:
+      required: true
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation method
+      options:
+        - Python
+        - Docker
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Runtime environment
+      description: Include the operating system, Python or Docker version, and client name when relevant.
+      placeholder: "Windows 11, Python 3.12, Cherry Studio"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal sequence using fake account and key values.
+      placeholder: |
+        1. Start...
+        2. Send...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Redacted logs
+      description: Include only the minimum relevant lines after replacing every credential and account identifier.
+      render: shell
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues for the same problem.
+          required: true
+        - label: I removed all credentials, tokens, API keys, account data, request content, and personal information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/wicm84266964/Buddy2api/security/policy
+    about: Read the private reporting instructions instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a Buddy2api workflow improvement
+title: "[Feature]: "
+body:
+  - type: input
+    id: workflow
+    attributes:
+      label: Workflow
+      description: Which local gateway or client-integration task would this improve?
+      placeholder: "For example: account diagnostics or OpenAI-compatible client setup"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Describe the current limitation without exposing account details.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues for a similar request.
+          required: true
+        - label: This request contains no credentials, tokens, API keys, account data, request content, or personal information.
+          required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest release and the current `main` branch. Older releases are not maintained unless a fix is explicitly backported.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for a suspected vulnerability. Use GitHub's **Report a vulnerability** option in the Security tab so the report and follow-up remain private.
+
+Include the affected version or commit, a minimal reproduction, the expected impact, and any suggested mitigation. Never attach Work Buddy or CodeBuddy credentials, access or refresh tokens, generated API keys, account databases, unredacted request logs, or personal information.
+
+You should receive an initial acknowledgement within 7 days. A validated report will be assessed and fixed according to its impact and exploitability.


### PR DESCRIPTION
## Summary
- add weekly Dependabot coverage for the repository's package ecosystems and GitHub Actions
- add a security policy with private, redacted reporting guidance
- add structured bug and feature issue forms with data-safety confirmations
- keep blank issues disabled and route security reports to the security policy

## Validation
- parsed all maintenance YAML with PyYAML
- verified Dependabot directories against dependency manifests
- ran git diff --check

No release is created by this maintenance change.