### PR TITLE
Resolve dependency advisories and reduce update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,27 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      routine-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      routine-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:
+      routine-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Validate release request

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-pytest==7.4.4
+pytest==9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==43.0.0
+cryptography==49.0.0
 fastapi==0.128.0
 httpx==0.27.0
 uvicorn[standard]==0.40.0


### PR DESCRIPTION
## Summary
- update cryptography to 49.0.0 and pytest to 9.1.1
- refresh GitHub Actions
- group routine minor/patch dependency updates monthly

## Validation
- pytest: 10/10 passed in a clean virtual environment
- Python compileall passed

This PR supersedes the separate Dependabot dependency PRs. No release is created.