### PR TITLE
fix: stabilize bridged tool call streams

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 __pycache__/
+.pytest_cache/
+.pytest-tmp*/
 *.pyc
 *.db
 *.db-wal

--- a/docs/releases/v1.4.3.md
+++ b/docs/releases/v1.4.3.md
@@ -1,0 +1,25 @@
+# Buddy2api v1.4.3
+
+发布日期：2026-07-25
+
+这是 `v1.4.2` 的小型兼容性更新，重点修复智能体经 sub2api 转发到 Buddy2api 时，并行工具调用在第二轮被上游拒绝或流式返回不完整的问题。
+
+## 主要更新
+
+- 将 Responses 输入中同一轮的多个 `function_call` 合并为一条 Chat Completions `assistant.tool_calls` 消息，保留调用 ID、函数名、参数和顺序。
+- 不跨越工具结果或用户消息合并，保持多轮工具调用的原始语义。
+- 兼容腾讯上游在中间分片中返回空字符串 `finish_reason` 的行为，对外规范化为 `null`，最终终止原因仍严格校验。
+- 加强 Chat Completions SSE 终止检查，防止缺少 `finish_reason` / `[DONE]`、损坏工具参数或终止后额外分片被误报为成功。
+- 上游在输出开始前失败时可切换备用账号，并在返回错误事件前完成失败日志记录。
+
+## 兼容与升级说明
+
+- 本次没有数据库结构迁移，已有配置和数据目录可以直接复用。
+- Docker 用户需要重新构建并重启服务：`docker compose up -d --build`。
+- sub2api 保持现有 `http://host.docker.internal:8787/v1` 账号配置即可，无需改动 Lab Agent 请求格式。
+
+## 验证
+
+- `python -m compileall -q .`
+- `python -m pytest -q`：71 passed
+- 实机链路 `Lab Agent 协议 -> sub2api:8080 -> Buddy2api:8787 -> 腾讯上游` 重放 5 个并行工具结果：HTTP 200、`finish_reason=stop`、1 个 `[DONE]`、0 个错误事件。

--- a/proxy.py
+++ b/proxy.py
@@ -153,6 +153,374 @@ def _err_sse_event(raw: bytes, status: int) -> bytes:
     return event.encode("utf-8")
 
 
+def _json_sse_event(payload: dict) -> bytes:
+    return ("data: " + json.dumps(payload, ensure_ascii=False) + "\n\n").encode("utf-8")
+
+
+def _has_terminal_choice(payload: dict) -> bool:
+    choices = payload.get("choices")
+    if not isinstance(choices, list):
+        return False
+    return any(
+        isinstance(choice, dict) and bool(choice.get("finish_reason"))
+        for choice in choices
+    )
+
+
+_MAX_SSE_EVENT_BYTES = 8 * 1024 * 1024
+
+
+class _ChatStreamObserver:
+    """Track completion state while Chat Completions SSE is normalized."""
+
+    def __init__(self, fallback_model: str, expected_choices: int = 1):
+        self.fallback_model = fallback_model
+        if not isinstance(expected_choices, int) or isinstance(expected_choices, bool):
+            expected_choices = 1
+        self.expected_choice_indices = set(range(expected_choices if 1 <= expected_choices <= 128 else 1))
+        self.seen_done = False
+        self.saw_chat_chunk = False
+        self.upstream_error = False
+        self.upstream_error_event: dict | None = None
+        self.finish_reasons: dict[int, str | None] = {}
+        self.closed_choices: set[int] = set()
+        self.content_choices: set[int] = set()
+        self.tool_call_choices: set[int] = set()
+        self.tool_calls: dict[tuple[int, int], dict] = {}
+        self.malformed_data_event = False
+        self.parser_error: str | None = None
+        self.usage: dict = {}
+        self.content_parts: list[str] = []
+        self.metadata: dict = {}
+
+    def observe_event(self, data: bytes) -> dict | None:
+        if data.strip() == b"[DONE]":
+            self.seen_done = True
+            return None
+        if self.seen_done:
+            self.parser_error = "The upstream sent data after the [DONE] event."
+            return None
+        try:
+            obj = json.loads(data)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self.malformed_data_event = True
+            return None
+        if not isinstance(obj, dict):
+            self.malformed_data_event = True
+            return None
+
+        if "error" in obj and obj["error"] is not None:
+            self.upstream_error = True
+            self.upstream_error_event = obj
+            return None
+
+        choices = obj.get("choices")
+        is_chat_chunk = obj.get("object") == "chat.completion.chunk" or "choices" in obj
+        if is_chat_chunk and not isinstance(choices, list):
+            self.parser_error = "The upstream Chat Completions chunk had an invalid choices field."
+            return None
+        if is_chat_chunk:
+            self.saw_chat_chunk = True
+            for key in ("id", "created", "model", "system_fingerprint", "service_tier"):
+                if key in obj:
+                    self.metadata[key] = obj[key]
+
+        event_usage = obj.get("usage")
+        if event_usage is not None and not isinstance(event_usage, dict):
+            self.parser_error = "The upstream Chat Completions chunk had invalid usage data."
+            return None
+        if isinstance(event_usage, dict):
+            self.usage.update(event_usage)
+        if not is_chat_chunk:
+            self.parser_error = "The upstream SSE event was not a Chat Completions chunk."
+            return None
+
+        validated_choices: list[tuple[int, dict, str | None]] = []
+        event_choice_indices: set[int] = set()
+        for choice in choices:
+            if not isinstance(choice, dict):
+                self.parser_error = "The upstream Chat Completions chunk contained an invalid choice."
+                return None
+            index = choice.get("index", 0)
+            if not isinstance(index, int) or isinstance(index, bool):
+                self.parser_error = "The upstream Chat Completions choice had an invalid index."
+                return None
+            if index not in self.expected_choice_indices:
+                self.parser_error = "The upstream Chat Completions choice index was not requested."
+                return None
+            if index in event_choice_indices:
+                self.parser_error = "The upstream Chat Completions chunk repeated a choice index."
+                return None
+            event_choice_indices.add(index)
+            if index in self.closed_choices:
+                self.parser_error = "The upstream sent another delta after a choice had finished."
+                return None
+            reason = choice.get("finish_reason")
+            if reason == "":
+                reason = None
+                choice["finish_reason"] = None
+            elif reason is not None and not isinstance(reason, str):
+                self.parser_error = "The upstream Chat Completions choice had an invalid finish reason."
+                return None
+            delta = choice.get("delta")
+            if not isinstance(delta, dict):
+                self.parser_error = "The upstream Chat Completions choice had an invalid delta."
+                return None
+            for content_field in ("content", "reasoning_content"):
+                content = delta.get(content_field)
+                if content is not None and not isinstance(content, str):
+                    self.parser_error = (
+                        f"The upstream Chat Completions choice had invalid {content_field}."
+                    )
+                    return None
+            tool_deltas = delta.get("tool_calls")
+            if tool_deltas is not None and not isinstance(tool_deltas, list):
+                self.parser_error = "The upstream Chat Completions choice had invalid tool calls."
+                return None
+            if isinstance(tool_deltas, list):
+                for position, tool_delta in enumerate(tool_deltas):
+                    if not isinstance(tool_delta, dict):
+                        self.parser_error = "The upstream tool call stream contained an invalid delta."
+                        return None
+                    tool_index = tool_delta.get("index", position)
+                    if (
+                        not isinstance(tool_index, int)
+                        or isinstance(tool_index, bool)
+                        or tool_index < 0
+                    ):
+                        self.parser_error = "The upstream tool call stream had an invalid index."
+                        return None
+                    call_id = tool_delta.get("id")
+                    if call_id is not None and (not isinstance(call_id, str) or not call_id):
+                        self.parser_error = "The upstream tool call stream had an invalid call id."
+                        return None
+                    call_type = tool_delta.get("type")
+                    if call_type is not None and call_type != "function":
+                        self.parser_error = "The upstream tool call stream had an invalid call type."
+                        return None
+                    function = tool_delta.get("function")
+                    if function is not None and not isinstance(function, dict):
+                        self.parser_error = "The upstream tool call stream had an invalid function."
+                        return None
+                    if isinstance(function, dict):
+                        name = function.get("name")
+                        if name is not None and (not isinstance(name, str) or not name):
+                            self.parser_error = "The upstream tool call stream had an invalid function name."
+                            return None
+                        arguments = function.get("arguments")
+                        if arguments is not None and not isinstance(arguments, str):
+                            self.parser_error = "The upstream tool call stream had invalid arguments."
+                            return None
+            validated_choices.append((index, delta, reason))
+
+        for index, delta, reason in validated_choices:
+            self.finish_reasons.setdefault(index, None)
+            if reason:
+                self.finish_reasons[index] = reason
+                self.closed_choices.add(index)
+            content = delta.get("content")
+            if content:
+                self.content_parts.append(content)
+                self.content_choices.add(index)
+            tool_deltas = delta.get("tool_calls")
+            if tool_deltas is None:
+                continue
+            if tool_deltas:
+                self.tool_call_choices.add(index)
+            for position, tool_delta in enumerate(tool_deltas):
+                tool_index = tool_delta.get("index", position)
+                state = self.tool_calls.setdefault(
+                    (index, tool_index),
+                    {"id": None, "name": None, "arguments": ""},
+                )
+                call_id = tool_delta.get("id")
+                if call_id:
+                    if state["id"] not in (None, call_id):
+                        self.parser_error = "The upstream tool call stream changed a call id."
+                        return None
+                    state["id"] = call_id
+                function = tool_delta.get("function")
+                if function is None:
+                    continue
+                name = function.get("name")
+                if name:
+                    if state["name"] not in (None, name):
+                        self.parser_error = "The upstream tool call stream changed a function name."
+                        return None
+                    state["name"] = name
+                arguments = function.get("arguments")
+                if arguments is None:
+                    continue
+                state["arguments"] += arguments
+        return obj
+
+    def missing_finish_choices(self) -> list[int]:
+        return sorted(index for index, reason in self.finish_reasons.items() if not reason)
+
+    def eof_error(self) -> str | None:
+        if self.parser_error:
+            return self.parser_error
+        if self.malformed_data_event:
+            return "The upstream stream ended with a malformed SSE JSON event."
+        if self.upstream_error:
+            return "The upstream returned an error event in an HTTP 200 stream."
+        if not self.saw_chat_chunk:
+            return "The upstream stream ended without a Chat Completions chunk."
+        missing_choices = self.expected_choice_indices.difference(self.finish_reasons)
+        if missing_choices:
+            return "The upstream stream ended before all requested choices were received."
+        for choice_index, reason in self.finish_reasons.items():
+            if reason == "tool_calls" and choice_index not in self.tool_call_choices:
+                return "The upstream ended with tool_calls but did not provide a tool call."
+            if choice_index in self.tool_call_choices and reason not in {
+                None,
+                "tool_calls",
+                "length",
+                "content_filter",
+            }:
+                return "The upstream tool call stream ended with an inconsistent finish reason."
+            if not reason and choice_index not in self.tool_call_choices:
+                return "The upstream stream ended before the choice received a finish reason."
+        for choice_index in self.tool_call_choices:
+            calls = [
+                state
+                for (current_choice, _), state in self.tool_calls.items()
+                if current_choice == choice_index
+            ]
+            if not calls:
+                return "The upstream tool call stream ended before the tool call was identified."
+            for state in calls:
+                if self.finish_reasons.get(choice_index) in {"length", "content_filter"}:
+                    continue
+                if not state["id"] or not state["name"]:
+                    return "The upstream tool call stream ended before the tool call was complete."
+                try:
+                    arguments = json.loads(state["arguments"])
+                except (json.JSONDecodeError, RecursionError, TypeError):
+                    return "The upstream tool call stream ended with incomplete JSON arguments."
+                if not isinstance(arguments, dict):
+                    return "The upstream tool call arguments were not a JSON object."
+        for choice_index, reason in self.finish_reasons.items():
+            if not reason and choice_index not in self.content_choices and choice_index not in self.tool_call_choices:
+                return "The upstream stream ended before the choice produced complete content."
+        return None
+
+    def terminal_event(self, choice_indices: list[int]) -> bytes:
+        payload = {
+            "id": self.metadata.get("id") or "chatcmpl-" + os.urandom(12).hex(),
+            "object": "chat.completion.chunk",
+            "created": self.metadata.get("created") or int(time.time()),
+            "model": self.metadata.get("model") or self.fallback_model,
+            "choices": [
+                {
+                    "index": index,
+                    "delta": {},
+                    "finish_reason": "tool_calls" if index in self.tool_call_choices else "stop",
+                }
+                for index in choice_indices
+            ],
+        }
+        for key in ("system_fingerprint", "service_tier"):
+            if key in self.metadata:
+                payload[key] = self.metadata[key]
+        return _json_sse_event(payload)
+
+
+class _SSEEventDecoder:
+    """Decode complete SSE data fields from arbitrary byte chunks."""
+
+    def __init__(self):
+        self.parser_error: str | None = None
+        self._buffer = b""
+        self._data_lines: list[bytes] = []
+        self._event_bytes = 0
+
+    def feed(self, chunk: bytes) -> list[bytes]:
+        if self.parser_error:
+            return []
+        self._buffer += chunk
+        events: list[bytes] = []
+        while True:
+            line = self._take_line()
+            if line is None:
+                break
+            event = self._consume_line(line)
+            if event is not None:
+                events.append(event)
+            if self.parser_error:
+                break
+        if not self.parser_error and len(self._buffer) > _MAX_SSE_EVENT_BYTES:
+            self._fail("The upstream SSE line exceeded the 8 MiB limit.")
+        return events
+
+    def finish(self) -> list[bytes]:
+        if self.parser_error:
+            return []
+        events: list[bytes] = []
+        while True:
+            line = self._take_line(final=True)
+            if line is None:
+                break
+            event = self._consume_line(line)
+            if event is not None:
+                events.append(event)
+            if self.parser_error:
+                return events
+        if self._data_lines:
+            events.append(b"\n".join(self._data_lines))
+            self._data_lines = []
+            self._event_bytes = 0
+        return events
+
+    def _take_line(self, *, final: bool = False) -> bytes | None:
+        for index, value in enumerate(self._buffer):
+            if value == 0x0A:
+                line = self._buffer[:index]
+                self._buffer = self._buffer[index + 1:]
+                return line[:-1] if line.endswith(b"\r") else line
+            if value == 0x0D:
+                if index + 1 == len(self._buffer) and not final:
+                    return None
+                end = index + 2 if self._buffer[index + 1:index + 2] == b"\n" else index + 1
+                line = self._buffer[:index]
+                self._buffer = self._buffer[end:]
+                return line
+        if final and self._buffer:
+            line = self._buffer
+            self._buffer = b""
+            return line
+        return None
+
+    def _consume_line(self, line: bytes) -> bytes | None:
+        if len(line) > _MAX_SSE_EVENT_BYTES:
+            self._fail("The upstream SSE line exceeded the 8 MiB limit.")
+            return None
+        if not line:
+            if not self._data_lines:
+                return None
+            event = b"\n".join(self._data_lines)
+            self._data_lines = []
+            self._event_bytes = 0
+            return event
+        if not line.startswith(b"data:"):
+            return None
+        data = line[5:]
+        if data.startswith(b" "):
+            data = data[1:]
+        self._event_bytes += len(data) + 1
+        if self._event_bytes > _MAX_SSE_EVENT_BYTES:
+            self._fail("The upstream SSE event exceeded the 8 MiB limit.")
+            return None
+        self._data_lines.append(data)
+        return None
+
+    def _fail(self, message: str) -> None:
+        self.parser_error = message
+        self._buffer = b""
+        self._data_lines = []
+        self._event_bytes = 0
+
+
 def _log_request(api_key_info, account, model_name, stream,
                   prompt_t, completion_t, total_t, credit,
                   finish_reason, status_code, error_msg, t0,
@@ -305,31 +673,53 @@ async def _stream_upstream(
     """Stream upstream SSE with pre-output account failover and backoff."""
     tried_ids: set[int] = set()
     last_error = b"No available accounts"
+    last_error_event: dict | None = None
     last_status = 503
     last_account = None
     last_started = time.time()
+    pending_retry_log: dict | None = None
 
     for attempt in range(3):
         account = await auth_manager.pick_account_with_fallback(tried_ids)
         if not account:
             break
+        if pending_retry_log is not None:
+            _log_request(
+                api_key_info,
+                pending_retry_log["account"],
+                model_name,
+                True,
+                pending_retry_log["prompt_tokens"],
+                pending_retry_log["completion_tokens"],
+                pending_retry_log["total_tokens"],
+                pending_retry_log["credit"],
+                "retry",
+                pending_retry_log["status"],
+                pending_retry_log["message"],
+                pending_retry_log["started"],
+                increment_usage=False,
+            )
+            await _retry_delay(pending_retry_log["attempt"])
+            pending_retry_log = None
         last_account = account
         tried_ids.add(account["id"])
         headers = await auth_manager.get_valid_headers(account)
         if not headers:
             auth_manager.mark_account_failure(account["id"], 401)
             last_error = b"Account credentials are invalid"
+            last_error_event = None
             last_status = 401
             continue
 
         url = f"{auth_manager.backend_url()}/v2/chat/completions"
         t0 = time.time()
         last_started = t0
-        finish_reason = None
-        usage: dict = {}
-        buf = b""
-        content_parts: list[str] = []
+        observer = _ChatStreamObserver(body.get("model") or model_name, body.get("n", 1))
+        decoder = _SSEEventDecoder()
         output_started = False
+        pending_terminal_events: list[bytes] = []
+        pending_terminal_bytes = 0
+        stop_reading = False
 
         try:
             timeout = httpx.Timeout(
@@ -343,91 +733,195 @@ async def _stream_upstream(
                     if response.status_code != 200:
                         raw_error = await response.aread()
                         last_error = raw_error
+                        last_error_event = None
                         last_status = response.status_code
                         auth_manager.mark_account_failure(account["id"], response.status_code)
                         if _is_retryable_status(response.status_code) and attempt < 2:
-                            _log_request(
-                                api_key_info, account, model_name, True,
-                                0, 0, 0, 0, "retry", response.status_code,
-                                raw_error.decode("utf-8", "replace")[:500], t0,
-                                increment_usage=False,
-                            )
-                            await _retry_delay(attempt)
+                            pending_retry_log = {
+                                "account": account,
+                                "prompt_tokens": 0,
+                                "completion_tokens": 0,
+                                "total_tokens": 0,
+                                "credit": 0,
+                                "status": response.status_code,
+                                "message": raw_error.decode("utf-8", "replace")[:500],
+                                "started": t0,
+                                "attempt": attempt,
+                            }
                             continue
-                        yield _err_sse_event(raw_error, response.status_code)
                         _log_request(
                             api_key_info, account, model_name, True,
                             0, 0, 0, 0, "error", response.status_code,
                             raw_error.decode("utf-8", "replace")[:500], t0,
                         )
+                        yield _err_sse_event(raw_error, response.status_code)
                         return
 
-                    auth_manager.mark_account_success(account["id"])
                     async for chunk in response.aiter_bytes():
                         if not chunk:
                             continue
-                        output_started = True
-                        buf += chunk
-                        while b"\n" in buf:
-                            line, buf = buf.split(b"\n", 1)
-                            line = line.strip()
-                            if not line.startswith(b"data:"):
-                                continue
-                            data = line[5:].strip()
-                            if data == b"[DONE]":
-                                continue
-                            try:
-                                obj = json.loads(data)
-                            except (json.JSONDecodeError, UnicodeDecodeError):
-                                continue
-                            if obj.get("usage"):
-                                usage.update(obj["usage"])
-                            for choice in obj.get("choices") or []:
-                                if choice.get("finish_reason"):
-                                    finish_reason = choice["finish_reason"]
-                                delta = choice.get("delta") or {}
-                                if delta.get("content"):
-                                    content_parts.append(delta["content"])
-                        yield chunk
+                        for data in decoder.feed(chunk):
+                            obj = observer.observe_event(data)
+                            if obj is not None and not obj.get("error"):
+                                encoded = _json_sse_event(obj)
+                                if pending_terminal_events or _has_terminal_choice(obj):
+                                    pending_terminal_events.append(encoded)
+                                    pending_terminal_bytes += len(encoded)
+                                    if pending_terminal_bytes > _MAX_SSE_EVENT_BYTES:
+                                        observer.parser_error = (
+                                            "The upstream terminal SSE events exceeded the 8 MiB limit."
+                                        )
+                                else:
+                                    output_started = True
+                                    yield encoded
+                            if (
+                                observer.seen_done
+                                or observer.parser_error
+                                or observer.malformed_data_event
+                                or observer.upstream_error
+                            ):
+                                stop_reading = True
+                                break
+                        if decoder.parser_error and not observer.seen_done:
+                            observer.parser_error = decoder.parser_error
+                            stop_reading = True
+                        if stop_reading:
+                            break
         except httpx.HTTPError as exc:
             last_error = str(exc).encode("utf-8", "replace")
+            last_error_event = None
             last_status = 502
             auth_manager.mark_account_failure(account["id"], 502)
             if not output_started and attempt < 2:
-                _log_request(
-                    api_key_info, account, model_name, True,
-                    0, 0, 0, 0, "retry", 502, str(exc)[:500], t0,
-                    increment_usage=False,
-                )
-                await _retry_delay(attempt)
+                pending_retry_log = {
+                    "account": account,
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                    "credit": 0,
+                    "status": 502,
+                    "message": str(exc)[:500],
+                    "started": t0,
+                    "attempt": attempt,
+                }
                 continue
-            yield _err_sse_event(last_error, 502)
             _log_request(
                 api_key_info, account, model_name, True,
                 0, 0, 0, 0, "network_error", 502, str(exc)[:500], t0,
             )
+            yield _err_sse_event(last_error, 502)
             return
 
-        full_text = "".join(content_parts)
+        if not stop_reading:
+            for data in decoder.finish():
+                obj = observer.observe_event(data)
+                if obj is not None and not obj.get("error"):
+                    encoded = _json_sse_event(obj)
+                    if pending_terminal_events or _has_terminal_choice(obj):
+                        pending_terminal_events.append(encoded)
+                        pending_terminal_bytes += len(encoded)
+                        if pending_terminal_bytes > _MAX_SSE_EVENT_BYTES:
+                            observer.parser_error = (
+                                "The upstream terminal SSE events exceeded the 8 MiB limit."
+                            )
+                    else:
+                        output_started = True
+                        yield encoded
+        if decoder.parser_error and not observer.seen_done:
+            observer.parser_error = decoder.parser_error
+
+        eof_error = observer.eof_error()
+        if eof_error:
+            last_error = (
+                json.dumps(observer.upstream_error_event, ensure_ascii=False).encode("utf-8")
+                if observer.upstream_error_event is not None
+                else eof_error.encode("utf-8")
+            )
+            last_error_event = observer.upstream_error_event
+            last_status = 502
+            auth_manager.mark_account_failure(account["id"], 502)
+            if not output_started and attempt < 2:
+                pending_retry_log = {
+                    "account": account,
+                    "prompt_tokens": observer.usage.get("prompt_tokens", 0),
+                    "completion_tokens": observer.usage.get("completion_tokens", 0),
+                    "total_tokens": observer.usage.get("total_tokens", 0),
+                    "credit": observer.usage.get("credit", 0),
+                    "status": 502,
+                    "message": eof_error,
+                    "started": t0,
+                    "attempt": attempt,
+                }
+                continue
+            _log_request(
+                api_key_info, account, model_name, True,
+                observer.usage.get("prompt_tokens", 0),
+                observer.usage.get("completion_tokens", 0),
+                observer.usage.get("total_tokens", 0),
+                observer.usage.get("credit", 0),
+                "error", 502, eof_error, t0,
+            )
+            if observer.upstream_error_event is not None:
+                yield _json_sse_event(observer.upstream_error_event)
+                yield b"data: [DONE]\n\n"
+            else:
+                yield _err_sse_event(eof_error.encode("utf-8"), 502)
+            return
+
+        missing_choices = observer.missing_finish_choices()
+        synthetic_terminal = None
+        if missing_choices:
+            synthetic_terminal = observer.terminal_event(missing_choices)
+            observer.finish_reasons.update({
+                index: "tool_calls" if index in observer.tool_call_choices else "stop"
+                for index in missing_choices
+            })
+        auth_manager.mark_account_success(account["id"])
+
+        full_text = "".join(observer.content_parts)
         audit_blocked = _looks_like_audit_block(full_text)
+        finish_reason = next((reason for reason in observer.finish_reasons.values() if reason), None)
         log_finish = "content_filter" if audit_blocked else (finish_reason or "stop")
         log_error = ("[audit blocked] " + full_text[:300]) if audit_blocked else ""
         _log_request(
             api_key_info, account, model_name, True,
-            usage.get("prompt_tokens", 0),
-            usage.get("completion_tokens", 0),
-            usage.get("total_tokens", 0),
-            usage.get("credit", 0),
+            observer.usage.get("prompt_tokens", 0),
+            observer.usage.get("completion_tokens", 0),
+            observer.usage.get("total_tokens", 0),
+            observer.usage.get("credit", 0),
             log_finish, 200, log_error, t0,
         )
+        for event in pending_terminal_events:
+            yield event
+        if synthetic_terminal is not None:
+            yield synthetic_terminal
+        yield b"data: [DONE]\n\n"
         return
 
-    yield _err_sse_event(last_error, last_status)
+    final_failure = pending_retry_log or {
+        "account": last_account,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "credit": 0,
+        "status": last_status,
+        "message": last_error.decode("utf-8", "replace")[:500],
+        "started": last_started,
+    }
     _log_request(
-        api_key_info, last_account, model_name, True,
-        0, 0, 0, 0, "error", last_status,
-        last_error.decode("utf-8", "replace")[:500], last_started,
+        api_key_info, final_failure["account"], model_name, True,
+        final_failure["prompt_tokens"],
+        final_failure["completion_tokens"],
+        final_failure["total_tokens"],
+        final_failure["credit"],
+        "error", final_failure["status"],
+        final_failure["message"], final_failure["started"],
     )
+    if last_error_event is not None:
+        yield _json_sse_event(last_error_event)
+        yield b"data: [DONE]\n\n"
+    else:
+        yield _err_sse_event(last_error, last_status)
 
 
 async def _collect_stream(

--- a/responses.py
+++ b/responses.py
@@ -123,17 +123,42 @@ def responses_to_chat(resp_payload: dict) -> dict:
     # input[] → messages[]
     inp = resp_payload.get("input")
     if isinstance(inp, list):
+        pending_tool_calls = []
         for item in inp:
             chat_msg = _input_item_to_chat_message(item)
-            if chat_msg:
-                # 清洗 system/developer 消息
-                if chat_msg.get("role") in ("system", "developer"):
-                    chat_msg["role"] = "system"
-                    content = chat_msg.get("content", "")
-                    chat_msg["content"] = _sanitize_system_content(
-                        content if isinstance(content, str) else _flatten_content(content)
-                    )
-                messages.append(chat_msg)
+            if not chat_msg:
+                continue
+
+            # Responses represents parallel calls as adjacent function_call items.
+            # Chat Completions requires those calls on one assistant message so the
+            # following tool results all belong to the same turn.
+            if chat_msg.get("role") == "assistant" and chat_msg.get("tool_calls"):
+                pending_tool_calls.extend(chat_msg["tool_calls"])
+                continue
+
+            if pending_tool_calls:
+                messages.append({
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": pending_tool_calls,
+                })
+                pending_tool_calls = []
+
+            # 清洗 system/developer 消息
+            if chat_msg.get("role") in ("system", "developer"):
+                chat_msg["role"] = "system"
+                content = chat_msg.get("content", "")
+                chat_msg["content"] = _sanitize_system_content(
+                    content if isinstance(content, str) else _flatten_content(content)
+                )
+            messages.append(chat_msg)
+
+        if pending_tool_calls:
+            messages.append({
+                "role": "assistant",
+                "content": None,
+                "tool_calls": pending_tool_calls,
+            })
     elif isinstance(inp, str) and inp.strip():
         messages.append({"role": "user", "content": inp})
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -49,6 +49,167 @@ def _events_of_type(events: list[tuple[str, dict]], event_name: str) -> list[dic
     return [payload for name, payload in events if name == event_name]
 
 
+def _collect_chat_proxy_stream(
+    chunks: list[bytes],
+    monkeypatch,
+    body: dict | None = None,
+    stream_error: Exception | None = None,
+) -> bytes:
+    class FakeResponse:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def aiter_bytes(self):
+            for chunk in chunks:
+                yield chunk
+            if stream_error is not None:
+                raise stream_error
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        def stream(self, *args, **kwargs):
+            return FakeResponse()
+
+    account = {"id": 1, "name": "test-account"}
+
+    async def pick_account(_excluded):
+        return account
+
+    async def valid_headers(_account):
+        return {"Authorization": "Bearer test"}
+
+    monkeypatch.setattr(auth_manager, "pick_account_with_fallback", pick_account)
+    monkeypatch.setattr(auth_manager, "get_valid_headers", valid_headers)
+    monkeypatch.setattr(auth_manager, "mark_account_success", lambda _account_id: None)
+    monkeypatch.setattr(auth_manager, "mark_account_failure", lambda *_args: None)
+    monkeypatch.setattr(auth_manager, "backend_url", lambda: "https://upstream.test")
+    monkeypatch.setattr(auth_manager, "request_timeout", lambda _default: 30)
+    monkeypatch.setattr(proxy, "_log_request", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(proxy.httpx, "AsyncClient", FakeAsyncClient)
+
+    async def collect():
+        return b"".join([
+            chunk
+            async for chunk in proxy._stream_upstream(
+                body or {"model": "test-model", "stream": True},
+                None,
+                "test-model",
+            )
+        ])
+
+    return asyncio.run(collect())
+
+
+def _parse_chat_proxy_sse(raw: bytes) -> tuple[list[dict], int]:
+    payloads = []
+    done_count = 0
+    for line in raw.decode("utf-8").splitlines():
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if data == "[DONE]":
+            done_count += 1
+        elif data:
+            payloads.append(json.loads(data))
+    return payloads, done_count
+
+
+def _assert_chat_proxy_error_only(raw: bytes) -> None:
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    assert len(payloads) == 1
+    assert payloads[0].get("error")
+    assert done_count == 1
+
+
+def _install_chat_account_stream_fakes(
+    monkeypatch,
+    accounts: list[dict],
+    streams: dict[int, list[bytes]],
+) -> dict:
+    calls = {
+        "picks": [],
+        "failures": [],
+        "successes": [],
+        "logs": [],
+        "delays": [],
+    }
+
+    class FakeResponse:
+        status_code = 200
+
+        def __init__(self, chunks):
+            self.chunks = chunks
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def aiter_bytes(self):
+            for chunk in self.chunks:
+                yield chunk
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        def stream(self, *args, headers, **kwargs):
+            account_id = int(headers["X-Test-Account"])
+            return FakeResponse(streams[account_id])
+
+    async def pick_account(excluded):
+        calls["picks"].append(set(excluded))
+        return next((account for account in accounts if account["id"] not in excluded), None)
+
+    async def valid_headers(account):
+        return {"X-Test-Account": str(account["id"])}
+
+    async def retry_delay(attempt):
+        calls["delays"].append(attempt)
+
+    def record_log(*args, **kwargs):
+        calls["logs"].append((args, kwargs))
+
+    monkeypatch.setattr(auth_manager, "pick_account_with_fallback", pick_account)
+    monkeypatch.setattr(auth_manager, "get_valid_headers", valid_headers)
+    monkeypatch.setattr(
+        auth_manager,
+        "mark_account_failure",
+        lambda account_id, status=0: calls["failures"].append((account_id, status)),
+    )
+    monkeypatch.setattr(
+        auth_manager,
+        "mark_account_success",
+        lambda account_id: calls["successes"].append(account_id),
+    )
+    monkeypatch.setattr(auth_manager, "backend_url", lambda: "https://upstream.test")
+    monkeypatch.setattr(auth_manager, "request_timeout", lambda _default: 30)
+    monkeypatch.setattr(proxy, "_retry_delay", retry_delay)
+    monkeypatch.setattr(proxy, "_log_request", record_log)
+    monkeypatch.setattr(proxy.httpx, "AsyncClient", FakeAsyncClient)
+    return calls
+
+
 @pytest.fixture()
 def isolated_db(tmp_path, monkeypatch):
     path = tmp_path / "gateway.db"
@@ -147,6 +308,82 @@ def test_responses_input_image_string_is_preserved():
         [{"type": "input_image", "image_url": "data:image/png;base64,abc"}]
     )
     assert "data:image/png;base64,abc" in flattened
+
+
+def test_responses_to_chat_groups_parallel_function_calls_across_reasoning_items():
+    payload = {
+        "model": "test-model",
+        "input": [
+            {"type": "message", "role": "user", "content": "Run both tools"},
+            {
+                "type": "function_call",
+                "call_id": "call_first",
+                "name": "first_tool",
+                "arguments": '{"value":1}',
+            },
+            {"type": "reasoning", "summary": []},
+            {
+                "type": "function_call",
+                "call_id": "call_second",
+                "name": "second_tool",
+                "arguments": {"value": 2},
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_first",
+                "output": {"ok": True},
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_second",
+                "output": "done",
+            },
+        ],
+    }
+
+    messages = responses.responses_to_chat(payload)["messages"]
+
+    assert [message["role"] for message in messages] == ["user", "assistant", "tool", "tool"]
+    assert [call["id"] for call in messages[1]["tool_calls"]] == ["call_first", "call_second"]
+    assert messages[1]["tool_calls"][1]["function"]["arguments"] == '{"value": 2}'
+    assert [message["tool_call_id"] for message in messages[2:]] == ["call_first", "call_second"]
+
+
+def test_responses_to_chat_keeps_sequential_function_call_turns_separate():
+    payload = {
+        "input": [
+            {
+                "type": "function_call",
+                "call_id": "call_first",
+                "name": "first_tool",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_first",
+                "output": "first result",
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_second",
+                "name": "second_tool",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_second",
+                "output": "second result",
+            },
+        ],
+    }
+
+    messages = responses.responses_to_chat(payload)["messages"]
+
+    assert [message["role"] for message in messages] == ["assistant", "tool", "assistant", "tool"]
+    assert [messages[0]["tool_calls"][0]["id"], messages[2]["tool_calls"][0]["id"]] == [
+        "call_first",
+        "call_second",
+    ]
 
 
 def test_responses_stream_reassembles_byte_split_tool_arguments():
@@ -430,6 +667,1026 @@ def test_responses_stream_supports_multiline_data_and_cr_line_endings():
     assert len(completed) == 1
     assert completed[0]["response"]["output"][0]["content"][0]["text"] == "hello"
     assert not _events_of_type(events, "response.failed")
+
+
+def test_chat_proxy_stream_does_not_duplicate_terminal_events(monkeypatch):
+    chunks = [
+        _chat_sse({
+            "id": "chatcmpl-complete",
+            "object": "chat.completion.chunk",
+            "created": 123,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "complete"},
+                "finish_reason": None,
+            }],
+        }),
+        _chat_sse({
+            "id": "chatcmpl-complete",
+            "object": "chat.completion.chunk",
+            "created": 123,
+            "model": "test-model",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        }),
+        b"data: [DONE]\n\n",
+    ]
+
+    raw = _collect_chat_proxy_stream(chunks, monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    finish_reasons = [
+        choice["finish_reason"]
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ]
+
+    assert finish_reasons == ["stop"]
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_normalizes_empty_finish_reason(monkeypatch):
+    chunks = [
+        _chat_sse({
+            "id": "chatcmpl-empty-finish",
+            "object": "chat.completion.chunk",
+            "created": 124,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "complete"},
+                "finish_reason": "",
+            }],
+        }),
+        _chat_sse({
+            "id": "chatcmpl-empty-finish",
+            "object": "chat.completion.chunk",
+            "created": 124,
+            "model": "test-model",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        }),
+        b"data: [DONE]\n\n",
+    ]
+
+    raw = _collect_chat_proxy_stream(chunks, monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert payloads[0]["choices"][0]["finish_reason"] is None
+    assert payloads[1]["choices"][0]["finish_reason"] == "stop"
+    assert not any(payload.get("error") for payload in payloads)
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_adds_done_after_explicit_terminal_at_eof(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-terminal-eof",
+            "object": "chat.completion.chunk",
+            "created": 321,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "complete"},
+                "finish_reason": "stop",
+            }],
+        }),
+    ], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert [
+        choice["finish_reason"]
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ] == ["stop"]
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_synthesizes_terminal_for_complete_tool_at_clean_eof(
+    monkeypatch,
+):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-eof",
+            "object": "chat.completion.chunk",
+            "created": 456,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_complete",
+                        "type": "function",
+                        "function": {"name": "shell", "arguments": '{"command":"pwd"}'},
+                    }],
+                },
+                "finish_reason": None,
+            }],
+        }),
+    ], monkeypatch)
+
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    terminal_choices = [
+        choice
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ]
+
+    assert len(terminal_choices) == 1
+    assert terminal_choices[0]["index"] == 0
+    assert terminal_choices[0]["delta"] == {}
+    assert terminal_choices[0]["finish_reason"] == "tool_calls"
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_rejects_plain_text_without_terminal_at_eof(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-text-eof",
+            "object": "chat.completion.chunk",
+            "created": 457,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "possibly incomplete"},
+                "finish_reason": None,
+            }],
+        }),
+    ], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len([payload for payload in payloads if payload.get("error")]) == 1
+    assert not any(
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload.get("choices") or []
+    )
+    assert done_count == 1
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        '{"command":"pwd"',
+        '{"command":pwd}',
+        '[]',
+    ],
+)
+def test_chat_proxy_stream_rejects_invalid_tool_arguments_at_eof(
+    monkeypatch,
+    arguments,
+):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-invalid-tool",
+            "object": "chat.completion.chunk",
+            "created": 789,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_invalid",
+                        "type": "function",
+                        "function": {"name": "shell", "arguments": arguments},
+                    }],
+                },
+                "finish_reason": None,
+            }],
+        }),
+    ], monkeypatch)
+
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    errors = [payload["error"] for payload in payloads if payload.get("error")]
+    terminal_choices = [
+        choice
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ]
+
+    assert len(errors) == 1
+    assert errors[0]["message"]
+    assert terminal_choices == []
+    assert done_count == 1
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        [],
+        [b": keepalive\n\n", b": still-alive\r\n\r\n"],
+    ],
+    ids=["empty", "comments-only"],
+)
+def test_chat_proxy_stream_rejects_empty_or_comment_only_streams(
+    monkeypatch,
+    chunks,
+):
+    raw = _collect_chat_proxy_stream(chunks, monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len([payload for payload in payloads if payload.get("error")]) == 1
+    assert not any(
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload.get("choices") or []
+    )
+    assert done_count == 1
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        [b"data: {not-json}\n\n"],
+        [b'data: {"choices":[{"index":0'],
+        [b"data: \xff\n\n"],
+    ],
+    ids=["malformed-json", "partial-frame", "invalid-utf8"],
+)
+def test_chat_proxy_stream_rejects_malformed_sse_at_eof(monkeypatch, chunks):
+    raw = _collect_chat_proxy_stream(chunks, monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len([payload for payload in payloads if payload.get("error")]) == 1
+    assert not any(
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload.get("choices") or []
+    )
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_decoder_reassembles_byte_split_utf8(monkeypatch):
+    wire = b"".join([
+        _chat_sse({
+            "id": "chatcmpl-byte-split",
+            "object": "chat.completion.chunk",
+            "created": 793,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "逐字节中文"},
+                "finish_reason": "stop",
+            }],
+        }),
+        b"data: [DONE]\n\n",
+    ])
+    raw = _collect_chat_proxy_stream([bytes([value]) for value in wire], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert [
+        choice["delta"]["content"]
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if (choice.get("delta") or {}).get("content")
+    ] == ["逐字节中文"]
+    assert not any(payload.get("error") for payload in payloads)
+    assert done_count == 1
+
+
+@pytest.mark.parametrize("line_ending", ["\n", "\r\n", "\r"], ids=["lf", "crlf", "cr"])
+def test_chat_proxy_stream_decoder_supports_sse_line_endings(
+    monkeypatch,
+    line_ending,
+):
+    payload = json.dumps({
+        "id": "chatcmpl-line-ending",
+        "object": "chat.completion.chunk",
+        "created": 794,
+        "model": "test-model",
+        "choices": [{
+            "index": 0,
+            "delta": {"content": "line ending"},
+            "finish_reason": "stop",
+        }],
+    }, separators=(",", ":"))
+    wire = (
+        f"data: {payload}{line_ending}{line_ending}"
+        f"data: [DONE]{line_ending}{line_ending}"
+    ).encode("utf-8")
+    raw = _collect_chat_proxy_stream([wire], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert [
+        choice["delta"]["content"]
+        for event in payloads
+        for choice in event.get("choices") or []
+        if (choice.get("delta") or {}).get("content")
+    ] == ["line ending"]
+    assert not any(event.get("error") for event in payloads)
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_decoder_supports_multiline_data(monkeypatch):
+    payload = json.dumps({
+        "id": "chatcmpl-multiline",
+        "object": "chat.completion.chunk",
+        "created": 795,
+        "model": "test-model",
+        "choices": [{
+            "index": 0,
+            "delta": {"content": "multiline"},
+            "finish_reason": "stop",
+        }],
+    }, separators=(",", ":"))
+    split_at = payload.index('"choices"')
+    wire = (
+        "event: message\r\n"
+        f"data: {payload[:split_at]}\r\n"
+        f"data: {payload[split_at:]}\r\n"
+        "\r\n"
+        "data: [DONE]\r\n\r\n"
+    ).encode("utf-8")
+    raw = _collect_chat_proxy_stream([bytes([value]) for value in wire], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert [
+        choice["delta"]["content"]
+        for event in payloads
+        for choice in event.get("choices") or []
+        if (choice.get("delta") or {}).get("content")
+    ] == ["multiline"]
+    assert not any(event.get("error") for event in payloads)
+    assert done_count == 1
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        b"data: " + (b"x" * 65) + b"\n\n",
+        b"data: " + (b"x" * 40) + b"\ndata: " + (b"y" * 40) + b"\n\n",
+    ],
+    ids=["line-limit", "event-limit"],
+)
+def test_chat_proxy_stream_decoder_enforces_eight_mib_limits(
+    monkeypatch,
+    wire,
+):
+    assert proxy._MAX_SSE_EVENT_BYTES == 8 * 1024 * 1024
+    monkeypatch.setattr(proxy, "_MAX_SSE_EVENT_BYTES", 64)
+
+    raw = _collect_chat_proxy_stream([wire], monkeypatch)
+
+    _assert_chat_proxy_error_only(raw)
+
+
+def test_chat_proxy_stream_done_ignores_oversized_trailing_line(monkeypatch):
+    monkeypatch.setattr(proxy, "_MAX_SSE_EVENT_BYTES", 512)
+    wire = b"".join([
+        _chat_sse({
+            "id": "chatcmpl-done-before-garbage",
+            "object": "chat.completion.chunk",
+            "created": 796,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }],
+        }),
+        b"data: [DONE]\n\n",
+        b"x" * 513,
+        b"\n\n",
+    ])
+
+    raw = _collect_chat_proxy_stream([wire], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert not any(payload.get("error") for payload in payloads)
+    assert [
+        choice["finish_reason"]
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ] == ["stop"]
+    assert done_count == 1
+
+
+@pytest.mark.parametrize(
+    "choices",
+    [
+        1,
+        ["not-a-choice"],
+        [{"index": "0", "delta": {"content": "invalid"}, "finish_reason": None}],
+        [{"index": 0, "delta": "not-a-delta", "finish_reason": None}],
+    ],
+    ids=["choices-not-list", "choice-not-object", "invalid-index", "delta-not-object"],
+)
+def test_chat_proxy_stream_rejects_invalid_chunk_schema_without_leaking(
+    monkeypatch,
+    choices,
+):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-invalid-schema",
+            "object": "chat.completion.chunk",
+            "created": 790,
+            "model": "test-model",
+            "choices": choices,
+        }),
+    ], monkeypatch)
+
+    _assert_chat_proxy_error_only(raw)
+
+
+@pytest.mark.parametrize(
+    ("finish_reason", "trailing_delta"),
+    [
+        ("stop", {"content": "late content"}),
+        ("tool_calls", {
+            "tool_calls": [{
+                "index": 0,
+                "id": "call_late",
+                "type": "function",
+                "function": {"name": "shell", "arguments": '{"command":"pwd"}'},
+            }],
+        }),
+    ],
+    ids=["content-after-stop", "tool-after-tool-terminal"],
+)
+def test_chat_proxy_stream_rejects_same_choice_delta_after_terminal(
+    monkeypatch,
+    finish_reason,
+    trailing_delta,
+):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-early-terminal",
+            "object": "chat.completion.chunk",
+            "created": 791,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": finish_reason,
+            }],
+        }),
+        _chat_sse({
+            "id": "chatcmpl-early-terminal",
+            "object": "chat.completion.chunk",
+            "created": 791,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": trailing_delta,
+                "finish_reason": None,
+            }],
+        }),
+        b"data: [DONE]\n\n",
+    ], monkeypatch)
+
+    _assert_chat_proxy_error_only(raw)
+
+
+def test_chat_proxy_stream_rejects_complete_tool_call_with_stop(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-tool-stop",
+            "object": "chat.completion.chunk",
+            "created": 792,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_stop",
+                        "type": "function",
+                        "function": {"name": "shell", "arguments": '{"command":"pwd"}'},
+                    }],
+                },
+                "finish_reason": None,
+            }],
+        }),
+        _chat_sse({
+            "id": "chatcmpl-tool-stop",
+            "object": "chat.completion.chunk",
+            "created": 792,
+            "model": "test-model",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        }),
+        b"data: [DONE]\n\n",
+    ], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len([payload for payload in payloads if payload.get("error")]) == 1
+    assert not any(
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload.get("choices") or []
+    )
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_preserves_http_200_error_event(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "error": {
+                "message": "upstream overloaded",
+                "type": "server_error",
+                "code": "overloaded",
+            },
+        }),
+    ], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    errors = [payload["error"] for payload in payloads if payload.get("error")]
+
+    assert len(errors) == 1
+    assert errors[0]["message"] == "upstream overloaded"
+    assert not any(payload.get("choices") for payload in payloads)
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_rejects_an_unfinished_choice(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-multiple",
+            "object": "chat.completion.chunk",
+            "created": 999,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "first"},
+                    "finish_reason": "stop",
+                },
+                {
+                    "index": 1,
+                    "delta": {"content": "second"},
+                    "finish_reason": None,
+                },
+            ],
+        }),
+    ], monkeypatch, body={"model": "test-model", "stream": True, "n": 2})
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    errors = [payload["error"] for payload in payloads if payload.get("error")]
+    terminal_choices = [
+        (choice["index"], choice["finish_reason"])
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ]
+
+    assert len(errors) == 1
+    assert terminal_choices == []
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_rejects_missing_expected_choice(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-missing-choice",
+            "object": "chat.completion.chunk",
+            "created": 1000,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "only one"},
+                "finish_reason": "stop",
+            }],
+        }),
+    ], monkeypatch, body={"model": "test-model", "stream": True, "n": 2})
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len([payload for payload in payloads if payload.get("error")]) == 1
+    assert [
+        choice["finish_reason"]
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ] == []
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_rejects_done_with_unfinished_choice(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-premature-done",
+            "object": "chat.completion.chunk",
+            "created": 1001,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "unfinished"},
+                "finish_reason": None,
+            }],
+        }),
+        b"data: [DONE]\n\n",
+    ], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len([payload for payload in payloads if payload.get("error")]) == 1
+    assert not any(
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload.get("choices") or []
+    )
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_discards_terminal_before_http_error(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-network-failure",
+            "object": "chat.completion.chunk",
+            "created": 1002,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }],
+        }),
+    ], monkeypatch, stream_error=proxy.httpx.ReadError("connection dropped"))
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len(payloads) == 1
+    assert payloads[0].get("error")
+    assert not any(
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload.get("choices") or []
+    )
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_ignores_data_after_done(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-before-done",
+            "object": "chat.completion.chunk",
+            "created": 1003,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }],
+        }),
+        b"data: [DONE]\n\n",
+        _chat_sse({
+            "id": "chatcmpl-after-done",
+            "object": "chat.completion.chunk",
+            "created": 1004,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "tool_calls",
+            }],
+        }),
+    ], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert not any(payload.get("error") for payload in payloads)
+    assert [
+        choice["finish_reason"]
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ] == ["stop"]
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_rejects_tool_finish_without_tool_delta(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-missing-tool",
+            "object": "chat.completion.chunk",
+            "created": 1005,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "tool_calls",
+            }],
+        }),
+        b"data: [DONE]\n\n",
+    ], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len([payload for payload in payloads if payload.get("error")]) == 1
+    assert not any(
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload.get("choices") or []
+    )
+    assert done_count == 1
+
+
+@pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
+def test_chat_proxy_stream_accepts_truncated_tools_with_explicit_finish(
+    monkeypatch,
+    finish_reason,
+):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-truncated-tool",
+            "object": "chat.completion.chunk",
+            "created": 1006,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_truncated",
+                        "type": "function",
+                        "function": {"name": "shell", "arguments": '{"command":"git'},
+                    }],
+                },
+                "finish_reason": None,
+            }],
+        }),
+        _chat_sse({
+            "id": "chatcmpl-truncated-tool",
+            "object": "chat.completion.chunk",
+            "created": 1006,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": finish_reason,
+            }],
+        }),
+        b"data: [DONE]\n\n",
+    ], monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert not any(payload.get("error") for payload in payloads)
+    assert [
+        choice["finish_reason"]
+        for payload in payloads
+        for choice in payload.get("choices") or []
+        if choice.get("finish_reason") is not None
+    ] == [finish_reason]
+    assert done_count == 1
+
+
+@pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
+@pytest.mark.parametrize(
+    "tool_deltas",
+    [
+        [{
+            "index": 0,
+            "id": "call_bad_function",
+            "type": "function",
+            "function": "not-an-object",
+        }],
+        [{
+            "index": 0,
+            "id": "call_bad_arguments",
+            "type": "function",
+            "function": {"name": "shell", "arguments": {"command": "git"}},
+        }],
+        [
+            {
+                "index": 0,
+                "id": "call_first",
+                "type": "function",
+                "function": {"name": "shell", "arguments": '{"command":"'},
+            },
+            {
+                "index": 0,
+                "id": "call_second",
+                "type": "function",
+                "function": {"arguments": "git"},
+            },
+        ],
+        [
+            {
+                "index": 0,
+                "id": "call_name_conflict",
+                "type": "function",
+                "function": {"name": "shell", "arguments": '{"command":"'},
+            },
+            {
+                "index": 0,
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "git"},
+            },
+        ],
+    ],
+    ids=["invalid-function", "invalid-arguments", "conflicting-id", "conflicting-name"],
+)
+def test_chat_proxy_stream_truncation_rejects_invalid_or_conflicting_tool_fields(
+    monkeypatch,
+    tool_deltas,
+    finish_reason,
+):
+    chunks = [
+        _chat_sse({
+            "id": "chatcmpl-invalid-truncated-tool",
+            "object": "chat.completion.chunk",
+            "created": 1007,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {"tool_calls": [tool_delta]},
+                "finish_reason": None,
+            }],
+        })
+        for tool_delta in tool_deltas
+    ]
+    chunks.extend([
+        _chat_sse({
+            "id": "chatcmpl-invalid-truncated-tool",
+            "object": "chat.completion.chunk",
+            "created": 1007,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": finish_reason,
+            }],
+        }),
+        b"data: [DONE]\n\n",
+    ])
+    raw = _collect_chat_proxy_stream(chunks, monkeypatch)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+
+    assert len([payload for payload in payloads if payload.get("error")]) == 1
+    assert not any(
+        choice.get("finish_reason")
+        for payload in payloads
+        for choice in payload.get("choices") or []
+    )
+    assert done_count == 1
+
+
+def test_chat_proxy_stream_fails_over_after_preoutput_malformed_stream(monkeypatch):
+    accounts = [
+        {"id": 1, "name": "malformed-account"},
+        {"id": 2, "name": "healthy-account"},
+    ]
+    streams = {
+        1: [b"data: {not-json}\n\n"],
+        2: [
+            _chat_sse({
+                "id": "chatcmpl-second-account",
+                "object": "chat.completion.chunk",
+                "created": 1008,
+                "model": "test-model",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"content": "second account"},
+                    "finish_reason": "stop",
+                }],
+            }),
+            b"data: [DONE]\n\n",
+        ],
+    }
+    calls = _install_chat_account_stream_fakes(monkeypatch, accounts, streams)
+
+    async def collect():
+        return b"".join([
+            chunk
+            async for chunk in proxy._stream_upstream(
+                {"model": "test-model", "stream": True},
+                None,
+                "test-model",
+            )
+        ])
+
+    raw = asyncio.run(collect())
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    retry_logs = [entry for entry in calls["logs"] if entry[0][8] == "retry"]
+    success_logs = [entry for entry in calls["logs"] if entry[0][9] == 200]
+
+    assert [payload["id"] for payload in payloads] == ["chatcmpl-second-account"]
+    assert payloads[0]["choices"][0]["delta"]["content"] == "second account"
+    assert done_count == 1
+    assert calls["picks"] == [set(), {1}]
+    assert calls["failures"] == [(1, 502)]
+    assert calls["successes"] == [2]
+    assert calls["delays"] == [0]
+    assert len(retry_logs) == 1
+    assert retry_logs[0][0][1]["id"] == 1
+    assert retry_logs[0][1]["increment_usage"] is False
+    assert len(success_logs) == 1
+    assert success_logs[0][0][1]["id"] == 2
+
+
+def test_chat_proxy_stream_preserves_final_usage_when_no_failover_account(monkeypatch):
+    accounts = [{"id": 1, "name": "only-account"}]
+    streams = {1: [
+        _chat_sse({
+            "id": "chatcmpl-missing-second-choice",
+            "object": "chat.completion.chunk",
+            "created": 1009,
+            "model": "test-model",
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }],
+            "usage": {
+                "prompt_tokens": 2,
+                "completion_tokens": 3,
+                "total_tokens": 5,
+                "credit": 1.25,
+            },
+        }),
+    ]}
+    calls = _install_chat_account_stream_fakes(monkeypatch, accounts, streams)
+
+    async def collect():
+        return b"".join([
+            chunk
+            async for chunk in proxy._stream_upstream(
+                {"model": "test-model", "stream": True, "n": 2},
+                None,
+                "test-model",
+            )
+        ])
+
+    raw = asyncio.run(collect())
+    final_error_logs = [entry for entry in calls["logs"] if entry[0][8] == "error"]
+
+    _assert_chat_proxy_error_only(raw)
+    assert calls["picks"] == [set(), {1}]
+    assert calls["failures"] == [(1, 502)]
+    assert calls["successes"] == []
+    assert len(final_error_logs) == 1
+    assert final_error_logs[0][0][1]["id"] == 1
+    assert final_error_logs[0][0][4:8] == (2, 3, 5, 1.25)
+    assert final_error_logs[0][0][9] == 502
+
+
+def test_chat_proxy_stream_records_success_before_terminal_is_consumed(monkeypatch):
+    accounts = [{"id": 1, "name": "healthy-account"}]
+    streams = {
+        1: [
+            _chat_sse({
+                "id": "chatcmpl-early-stop",
+                "object": "chat.completion.chunk",
+                "created": 1009,
+                "model": "test-model",
+                "choices": [{
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop",
+                }],
+            }),
+            b"data: [DONE]\n\n",
+        ],
+    }
+    calls = _install_chat_account_stream_fakes(monkeypatch, accounts, streams)
+
+    async def consume_first():
+        generator = proxy._stream_upstream(
+            {"model": "test-model", "stream": True},
+            None,
+            "test-model",
+        )
+        first = await anext(generator)
+        assert calls["successes"] == [1]
+        assert len(calls["logs"]) == 1
+        assert calls["logs"][0][0][8] == "stop"
+        await generator.aclose()
+        return first
+
+    first = asyncio.run(consume_first())
+    payloads, done_count = _parse_chat_proxy_sse(first)
+
+    assert payloads[0]["choices"][0]["finish_reason"] == "stop"
+    assert done_count == 0
+    assert calls["failures"] == []
+    assert calls["successes"] == [1]
+    assert len(calls["logs"]) == 1
+    assert calls["logs"][0][0][8] == "stop"
+    assert calls["logs"][0][0][9] == 200
+
+
+def test_chat_proxy_stream_records_failure_before_error_is_consumed(monkeypatch):
+    accounts = [{"id": 1, "name": "only-account"}]
+    streams = {1: [b"data: {not-json}\n\n"]}
+    calls = _install_chat_account_stream_fakes(monkeypatch, accounts, streams)
+
+    async def consume_first():
+        generator = proxy._stream_upstream(
+            {"model": "test-model", "stream": True},
+            None,
+            "test-model",
+        )
+        first = await anext(generator)
+        assert calls["failures"] == [(1, 502)]
+        assert len([entry for entry in calls["logs"] if entry[0][8] == "error"]) == 1
+        await generator.aclose()
+        return first
+
+    first = asyncio.run(consume_first())
+    final_error_logs = [entry for entry in calls["logs"] if entry[0][8] == "error"]
+
+    _assert_chat_proxy_error_only(first)
+    assert calls["failures"] == [(1, 502)]
+    assert calls["successes"] == []
+    assert len(final_error_logs) == 1
+    assert final_error_logs[0][0][9] == 502
 
 
 def test_retryable_statuses_are_explicit():

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.4.2"
+VERSION = "1.4.3"

--- a/web/index.html
+++ b/web/index.html
@@ -388,7 +388,7 @@ createApp({
   template:`
   <div class="layout">
     <header class="topbar">
-      <div class="brand-block"><div class="brand-symbol">B2</div><div class="brand-copy"><div class="brand-title">Buddy 2 API</div><div class="brand-meta">Local model gateway · v1.4.2</div></div></div>
+      <div class="brand-block"><div class="brand-symbol">B2</div><div class="brand-copy"><div class="brand-title">Buddy 2 API</div><div class="brand-meta">Local model gateway · v1.4.3</div></div></div>
       <nav class="topnav"><div v-for="n in nav" :key="n.k" class="nav-item" :class="{on:page===n.k}" @click="go(n.k)" v-html="n.i+'<span>'+n.l+'</span>'"></div></nav>
       <div class="top-actions">
         <button class="refresh-cta" @click="hardRefresh"><span v-html="I.refresh"></span><span>刷新</span></button>


### PR DESCRIPTION
## Summary

- validate Chat Completions SSE terminal state and malformed tool-call streams
- group parallel Responses `function_call` items into one Chat assistant turn
- normalize CodeBuddy's empty intermediate `finish_reason` to `null`
- prepare the v1.4.3 patch release

## Root cause

sub2api converts the Lab Agent Chat request to `/v1/responses`. Buddy2api converted five parallel `function_call` items into five consecutive assistant messages, which CodeBuddy rejected with `11133 Invalid request parameters`. After grouping them, the same request succeeds. CodeBuddy also emits `finish_reason: ""` on intermediate chunks, which must be treated as a non-terminal value.

## Verification

- `python -m pytest -q`: 71 passed
- `python -m compileall -q`: passed for application and tests
- `git diff --check`: passed
- credential scan: no real keys, tokens, private keys, JWTs, or sensitive files
- live chain `sub2api:8080 -> Buddy2api:8787 -> CodeBuddy`: HTTP 200, `finish_reason=stop`, one `[DONE]`, zero error events with five parallel tool results