### PR TITLE
fix: reject empty successful responses

### DIFF
--- a/docs/releases/v1.4.5.md
+++ b/docs/releases/v1.4.5.md
@@ -1,0 +1,34 @@
+# Buddy2api v1.4.5
+
+发布日期：2026-08-08
+
+这是 `v1.4.4` 的稳定性修复版本，解决少数上游请求以成功状态结束、但没有返回任何可展示正文或工具调用时，Buddy2api 仍将响应报告为正常完成的问题。
+
+## 问题表现
+
+- 腾讯上游偶发只返回 `finish_reason=stop` 和 `[DONE]`，但没有 `content` 或 `tool_calls`。
+- 旧版本会将该响应记录为 HTTP 200，并在 Responses API 中生成 `status=completed`、`output=[]`。
+- 部分客户端因此显示“没有可展示正文”，同时无法区分正常空回复和异常上游响应。
+- 仅返回 `reasoning_content`、没有最终正文或工具调用的流式响应也可能产生相同结果。
+
+## 修复内容
+
+- Chat Completions 流式代理现在按每个 choice 校验是否实际产生了正文或工具调用；空 `stop` 不再被视为成功。
+- 在正文尚未向客户端输出时，空响应会按可重试的 502 上游错误处理，并允许切换备用账号。
+- 非流式 SSE 聚合增加相同校验，不再合成 `content=null`、`finish_reason=stop` 的伪成功响应。
+- Responses API 流式和非流式转换增加防御校验，禁止生成 `completed + output=[]`；无法展示的空完成会返回明确失败状态。
+- 保留 `length` 和 `content_filter` 的既有语义：即使没有正文，也会标记为 `incomplete`，不会误报为普通上游错误。
+
+## 兼容与升级说明
+
+- 正常正文响应、工具调用和多 choice 流程不受影响。
+- 本次没有数据库结构迁移，已有账号、API Key、日志和数据目录可以直接复用。
+- sub2api 保持现有 `http://host.docker.internal:8787/v1` 配置即可，无需修改调用格式。
+- Docker 用户需要重新构建并重启服务：`docker compose up -d --build`。
+
+## 验证
+
+- 新增空 `stop`、仅 `reasoning_content`、非流式空聚合及 Responses 空输出回归测试。
+- 更新原有正常终止测试，使其包含最小有效正文。
+- `python -m compileall -q proxy.py responses.py tests/test_core.py`
+- `python -m pytest -q`：79 passed

--- a/proxy.py
+++ b/proxy.py
@@ -404,8 +404,12 @@ class _ChatStreamObserver:
                 if not isinstance(arguments, dict):
                     return "The upstream tool call arguments were not a JSON object."
         for choice_index, reason in self.finish_reasons.items():
-            if not reason and choice_index not in self.content_choices and choice_index not in self.tool_call_choices:
-                return "The upstream stream ended before the choice produced complete content."
+            if (
+                reason not in {"length", "content_filter"}
+                and choice_index not in self.content_choices
+                and choice_index not in self.tool_call_choices
+            ):
+                return "The upstream choice ended without content or a tool call."
         return None
 
     def terminal_event(self, choice_indices: list[int]) -> bytes:
@@ -991,6 +995,21 @@ async def _collect_stream(
             for _, v in sorted(tool_calls.items())
         ]
         finish_reason = finish_reason or "tool_calls"
+
+    if (
+        not content_parts
+        and not tool_calls
+        and finish_reason not in {"length", "content_filter"}
+    ):
+        return (
+            "error",
+            (502, {
+                "error": {
+                    "message": "The upstream choice ended without content or a tool call.",
+                    "type": "upstream_error",
+                },
+            }),
+        )
 
     message = {"role": "assistant", "content": "".join(content_parts) or None}
     if reasoning_parts:

--- a/responses.py
+++ b/responses.py
@@ -459,14 +459,37 @@ def chat_response_to_responses(chat_resp: dict, model: str) -> dict:
                 "status": "completed",
             })
 
+    finish_reasons = {
+        choice.get("finish_reason")
+        for choice in chat_resp.get("choices") or []
+        if choice.get("finish_reason")
+    }
+    status = "completed"
+    incomplete_details = None
+    error = None
+    if "length" in finish_reasons:
+        status = "incomplete"
+        incomplete_details = {"reason": "max_output_tokens"}
+    elif "content_filter" in finish_reasons:
+        status = "incomplete"
+        incomplete_details = {"reason": "content_filter"}
+    elif not output:
+        status = "failed"
+        error = {
+            "code": "empty_upstream_response",
+            "message": "The upstream response contained no displayable content or tool call.",
+        }
+
     usage = chat_resp.get("usage") or {}
     return {
         "id": resp_id,
         "object": "response",
         "created_at": int(time.time()),
-        "status": "completed",
+        "status": status,
         "model": chat_resp.get("model") or model,
         "output": output,
+        "error": error,
+        "incomplete_details": incomplete_details,
         "usage": {
             "input_tokens": usage.get("prompt_tokens", 0),
             "output_tokens": usage.get("completion_tokens", 0),
@@ -574,6 +597,7 @@ async def chat_stream_to_responses_stream(
     usage: dict = {}
     seen_choices: set[int] = set()
     finished_choices: dict[int, str] = {}
+    productive_choices: set[int] = set()
     saw_done = False
     stream_error: Optional[dict] = None
 
@@ -713,6 +737,7 @@ async def chat_stream_to_responses_stream(
                 if text:
                     if not isinstance(text, str):
                         text = str(text)
+                    productive_choices.add(choice_index)
                     state = text_states.get(choice_index)
                     if state is None:
                         item = {
@@ -769,6 +794,7 @@ async def chat_stream_to_responses_stream(
                 for tc in delta.get("tool_calls") or []:
                     if not isinstance(tc, dict):
                         continue
+                    productive_choices.add(choice_index)
                     try:
                         tool_index = int(tc.get("index", 0))
                     except (TypeError, ValueError):
@@ -860,6 +886,16 @@ async def chat_stream_to_responses_stream(
         stream_error = {
             "code": "upstream_stream_ended",
             "message": "The upstream stream ended before a terminal event.",
+        }
+    elif not seen_choices or not output_items or any(
+        reason not in {"length", "content_filter"}
+        and choice_index not in productive_choices
+        for choice_index, reason in finished_choices.items()
+    ):
+        terminal_status = "failed"
+        stream_error = {
+            "code": "empty_upstream_response",
+            "message": "The upstream response contained no displayable content or tool call.",
         }
 
     if terminal_status == "completed":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -628,6 +628,28 @@ def test_responses_stream_emits_complete_text_lifecycle():
     assert completed["output"][0]["content"][0]["text"] == "hello"
 
 
+@pytest.mark.parametrize(
+    ("delta", "finish_reason"),
+    [
+        ({}, "stop"),
+        ({"reasoning_content": "internal only"}, "stop"),
+        ({}, None),
+    ],
+)
+def test_responses_stream_rejects_completed_choice_without_output(delta, finish_reason):
+    events = _collect_response_events([
+        _chat_sse({
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }),
+        b"data: [DONE]\n\n",
+    ])
+
+    failed = _events_of_type(events, "response.failed")
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "empty_upstream_response"
+    assert not _events_of_type(events, "response.completed")
+
+
 def test_responses_stream_fails_when_only_one_choice_finishes_before_eof():
     events = _collect_response_events([
         _chat_sse({
@@ -703,6 +725,91 @@ def test_chat_proxy_stream_does_not_duplicate_terminal_events(monkeypatch):
 
     assert finish_reasons == ["stop"]
     assert done_count == 1
+
+
+def test_chat_proxy_stream_rejects_terminal_without_content(monkeypatch):
+    raw = _collect_chat_proxy_stream([
+        _chat_sse({
+            "id": "chatcmpl-empty",
+            "object": "chat.completion.chunk",
+            "created": 123,
+            "model": "test-model",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        }),
+        b"data: [DONE]\n\n",
+    ], monkeypatch)
+
+    _assert_chat_proxy_error_only(raw)
+
+
+def test_non_stream_chat_conversion_rejects_empty_completed_response():
+    converted = responses.chat_response_to_responses({
+        "id": "chatcmpl-empty",
+        "model": "test-model",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": None},
+            "finish_reason": "stop",
+        }],
+        "usage": {},
+    }, "test-model")
+
+    assert converted["status"] == "failed"
+    assert converted["output"] == []
+    assert converted["error"]["code"] == "empty_upstream_response"
+
+
+@pytest.mark.parametrize("delta", [{}, {"reasoning_content": "internal only"}])
+def test_non_stream_aggregator_rejects_terminal_without_output(monkeypatch, delta):
+    payload = {
+        "id": "chatcmpl-empty",
+        "object": "chat.completion.chunk",
+        "model": "test-model",
+        "choices": [{"index": 0, "delta": delta, "finish_reason": "stop"}],
+    }
+
+    class FakeResponse:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def aiter_lines(self):
+            yield "data: " + json.dumps(payload)
+            yield "data: [DONE]"
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        def stream(self, *args, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(proxy.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(auth_manager, "request_timeout", lambda _default: 30)
+
+    result = asyncio.run(proxy._collect_stream(
+        "https://upstream.test/v2/chat/completions",
+        {"Authorization": "Bearer test"},
+        {"model": "test-model", "stream": True},
+        {"id": 1, "name": "test-account"},
+        None,
+        "test-model",
+        0,
+    ))
+
+    assert result[0] == "error"
+    assert result[1][0] == 502
+    assert "without content" in result[1][1]["error"]["message"]
 
 
 def test_chat_proxy_stream_normalizes_empty_finish_reason(monkeypatch):
@@ -1126,7 +1233,7 @@ def test_chat_proxy_stream_done_ignores_oversized_trailing_line(monkeypatch):
             "model": "test-model",
             "choices": [{
                 "index": 0,
-                "delta": {},
+                "delta": {"content": "done"},
                 "finish_reason": "stop",
             }],
         }),
@@ -1405,7 +1512,7 @@ def test_chat_proxy_stream_ignores_data_after_done(monkeypatch):
             "model": "test-model",
             "choices": [{
                 "index": 0,
-                "delta": {},
+                "delta": {"content": "done"},
                 "finish_reason": "stop",
             }],
         }),
@@ -1710,7 +1817,7 @@ def test_chat_proxy_stream_records_success_before_terminal_is_consumed(monkeypat
                 "model": "test-model",
                 "choices": [{
                     "index": 0,
-                    "delta": {},
+                    "delta": {"content": "done"},
                     "finish_reason": "stop",
                 }],
             }),

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.4.4"
+VERSION = "1.4.5"

--- a/web/index.html
+++ b/web/index.html
@@ -388,7 +388,7 @@ createApp({
   template:`
   <div class="layout">
     <header class="topbar">
-      <div class="brand-block"><div class="brand-symbol">B2</div><div class="brand-copy"><div class="brand-title">Buddy 2 API</div><div class="brand-meta">Local model gateway · v1.4.4</div></div></div>
+      <div class="brand-block"><div class="brand-symbol">B2</div><div class="brand-copy"><div class="brand-title">Buddy 2 API</div><div class="brand-meta">Local model gateway · v1.4.5</div></div></div>
       <nav class="topnav"><div v-for="n in nav" :key="n.k" class="nav-item" :class="{on:page===n.k}" @click="go(n.k)" v-html="n.i+'<span>'+n.l+'</span>'"></div></nav>
       <div class="top-actions">
         <button class="refresh-cta" @click="hardRefresh"><span v-html="I.refresh"></span><span>刷新</span></button>


### PR DESCRIPTION
## Summary

- reject upstream `stop` responses that contain neither displayable content nor tool calls
- apply the same validation to streaming, non-streaming, and Responses API conversions
- preserve `length` and `content_filter` as explicit incomplete responses
- prepare the patch release metadata and Chinese release notes for v1.4.5

## User-visible fix

Previously, a rare upstream response containing only `finish_reason=stop` and `[DONE]` could be returned as HTTP 200 and converted to `status=completed, output=[]`. Some clients then displayed "没有可展示正文". These responses are now treated as retryable upstream failures before output starts, and Responses API conversion can no longer report an empty output as completed.

## Compatibility

- normal text and tool-call responses are unchanged
- empty `length` and `content_filter` responses remain incomplete rather than failed
- no database migration or sub2api configuration change is required

## Verification

- `python -m compileall -q proxy.py responses.py tests/test_core.py`
- `python -m pytest -q` (79 passed)