### PR TITLE
补齐 Buddy2api v1.3.0 发布档案

### DIFF
--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,28 @@
+# Buddy2api v1.3.0
+
+发布日期：2026-06-30
+
+这是 Buddy2api 首个支持 OpenAI Responses API 的版本，使 Codex、OpenCode 等兼容客户端可以通过现有网关接入 Work Buddy 上游。
+
+## 主要更新
+
+- 新增 `/v1/responses` 端点，支持非流式响应和流式 SSE 事件。
+- 增加 Codex system prompt 分步清理策略；提示过长时使用最小安全版本，降低上游内容审核误拦截。
+- 识别腾讯上游的内容审核拦截响应，并在日志中记录为 `content_filter`，避免与普通网络或协议失败混淆。
+- 保留 `python`、`bash`、`powershell` 等工具名称，避免清理过程破坏 Codex 工具调用。
+- 增加受 `CB_DEBUG_DUMP` 环境变量控制的调试转储，默认关闭。
+- 补充相关管理接口和界面支持，并对同优先级账号使用粘性路由以提高上游缓存命中率。
+
+## 兼容说明
+
+- 兼容 OpenAI Responses API 的客户端可以将 Base URL 指向 Buddy2api。
+- 原有 `/v1/chat/completions` 和 `/v1/models` 接口继续保留。
+- 本版本不要求迁移已有账号或 API Key 配置。
+
+## 验证
+
+- 非流式 `/v1/responses` 请求通过。
+- 流式 SSE 输出通过。
+- Codex CLI 接入通过。
+- 内容审核拦截场景可正确记录为 `content_filter`。
+


### PR DESCRIPTION
## 内容

- 根据已合并 PR、正式提交和线上 Release 补齐 v1.3.0 版本说明
- 记录 Responses API、内容审核处理与客户端兼容性
- 补充升级边界和原始验证结果