### PR TITLE
fix: neutral outbound User-Agent; guard codex sanitize behind prompt markers

### DIFF
--- a/auth_manager.py
+++ b/auth_manager.py
@@ -22,11 +22,18 @@ from typing import Optional
 import httpx
 
 import database as db
-from version import VERSION
 
 BACKEND = "https://copilot.tencent.com"
 DEFAULT_DOMAIN = "www.codebuddy.cn"
-USER_AGENT = f"buddy2api/{VERSION}"
+
+# 默认使用通用浏览器 UA，避免在请求头中自曝网关身份（原 UA 为 buddy2api/x.y.z，
+# 调用方一眼可辨）。如需自定义，设置环境变量 CB_GATEWAY_USER_AGENT。
+_DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Safari/537.36"
+)
+USER_AGENT = os.environ.get("CB_GATEWAY_USER_AGENT") or _DEFAULT_USER_AGENT
 
 _lock = threading.Lock()
 _token_locks: dict[int, asyncio.Lock] = {}

--- a/responses.py
+++ b/responses.py
@@ -70,7 +70,20 @@ def apply_codex_sanitize(chat_payload: dict) -> dict:
     """
     对 Chat Completions 请求应用 Codex 专用清洗。
     用于 client_type='codex' 的 API Key，即使请求直接打到 /v1/chat/completions 也做清洗。
+
+    仅当请求携带 Codex 特征 prompt 时才改写；DSH/OpenClaw 等其它客户端
+    借用 codex key 时原样透传，避免清洗破坏其 agent 指令与工具定义。
     """
+    # 无 Codex 特征：不改写
+    if not any(
+        isinstance(msg, dict) and _looks_like_codex_prompt(
+            msg.get("content") if isinstance(msg.get("content"), str) else _flatten_content(msg.get("content") or "")
+        )
+        for msg in chat_payload.get("messages") or []
+        if isinstance(msg, dict) and msg.get("role") in ("system", "developer")
+    ):
+        return chat_payload
+
     # 清洗 system messages
     for msg in chat_payload.get("messages", []):
         if not isinstance(msg, dict):
@@ -369,16 +382,44 @@ _SANITIZE_REMOVE_SECTIONS = [
 ]
 
 
+_CODEX_PROMPT_MARKERS = (
+    "<permissions instructions>",
+    "Escalation Requests",
+    "Filesystem sandboxing",
+    "sandbox_mode",
+    "require_escalated",
+    "escalated permissions",
+    "security policy",
+    "shell access",
+)
+
+
+def _looks_like_codex_prompt(content: str) -> bool:
+    """判断 system prompt 是否来自 Codex 客户端。
+
+    清洗只对 Codex 风格 prompt 生效。其他 agent（DSH、OpenClaw 等）的
+    prompt 不含这些标记，直接原样透传，避免误伤：DSH 等 harness 的
+    prompt 远超 1200 字符，一旦被兜底规则整体替换成最小安全 prompt，
+    模型会丢失全部工具使用指令，退化成纯对话。
+    """
+    if not content:
+        return False
+    return any(marker in content for marker in _CODEX_PROMPT_MARKERS)
+
+
 def _sanitize_system_content(content: str) -> str:
     """清洗 system message 内容，避免触发腾讯内容审核。
 
     策略：
+      0) 非 Codex 特征 prompt 原样返回（不改写其他客户端）
       1) 先用正则删除整段高风险文本
       2) 再逐词替换已知触发词
       3) 如果清洗后仍然过长（>1200 字符）或仍含高风险关键词，
          直接用最小安全 prompt 替换，保证不再触发审核
     """
     if not content:
+        return content
+    if not _looks_like_codex_prompt(content):
         return content
 
     result = content

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2030,3 +2030,49 @@ def test_valid_headers_is_async_and_uses_decrypted_token(isolated_db):
     account = db.get_account(account_id)
     headers = asyncio.run(__import__("auth_manager").get_valid_headers(account))
     assert headers["Authorization"] == "Bearer access-secret"
+
+
+def test_codex_sanitize_skips_non_codex_prompts():
+    """DSH 等非 Codex prompt 不应被清洗或整体替换。"""
+    dsh_prompt = "You are DSH, an autonomous agent. Use tools: sandbox access, execute shell commands, filesystem. " + ("x" * 2000)
+    payload = {
+        "model": "auto",
+        "messages": [
+            {"role": "system", "content": dsh_prompt},
+            {"role": "user", "content": "run the workflow"},
+        ],
+        "tools": [{"type": "function", "function": {"name": "bash", "description": "execute shell commands"}}],
+    }
+    out = responses.apply_codex_sanitize(dict(payload))
+    assert out["messages"][0]["content"] == dsh_prompt
+    # 工具原样保留（codex 路径会过滤非 function 工具，但这里不触发清洗）
+    assert out["tools"][0]["function"]["description"] == "execute shell commands"
+
+
+def test_codex_sanitize_still_sanitizes_codex_prompts():
+    """带 Codex 特征的 prompt 仍走清洗。"""
+    codex_prompt = (
+        "<permissions instructions>\nFilesystem sandboxing defines which files can be read or written.\n"
+        "sandbox_mode=workspace\n</permissions instructions>\n"
+        "# Escalation Requests\nYou may request escalation.\n"
+        "security policy: do not delete files. " + ("y" * 2000)
+    )
+    payload = {
+        "model": "auto",
+        "messages": [{"role": "system", "content": codex_prompt}, {"role": "user", "content": "hi"}],
+        "tools": [{"type": "function", "function": {"name": "bash", "description": "execute shell commands and sandbox"}}],
+    }
+    out = responses.apply_codex_sanitize(dict(payload))
+    cleaned = out["messages"][0]["content"]
+    assert cleaned != codex_prompt
+    assert "Filesystem sandboxing" not in cleaned
+    assert "security policy" not in cleaned
+    # Codex 特征段落被移除/清洗（本例所有特征段被删除后为空串，同样证明清洗生效）
+    assert cleaned == "" or "coding assistant" in cleaned
+
+
+def test_codex_sanitize_passthrough_without_system_prompt():
+    """无 system message 时原样返回。"""
+    payload = {"model": "auto", "messages": [{"role": "user", "content": "hello"}]}
+    out = responses.apply_codex_sanitize(dict(payload))
+    assert out == payload


### PR DESCRIPTION
## Changes

### 1. Neutral outbound User-Agent (issue #30)

Outbound requests to the upstream backend no longer announce `buddy2api/x.y.z` in the User-Agent header. Defaults to a generic browser UA, overridable via `CB_GATEWAY_USER_AGENT`.

This stops self-identification of the gateway; it does not impersonate the official client.

### 2. Guard codex sanitize behind prompt markers

`apply_codex_sanitize` previously rewrote every request using a `codex`-type API key. If a non-Codex agent (DSH, OpenClaw, ...) borrowed such a key, its long system prompt could be replaced wholesale by the 1200-char fallback (minimal safe prompt), stripping agent tool instructions and turning runs into plain chat.

Now sanitize only runs when the system prompt carries Codex markers (`<permissions instructions>`, `Escalation Requests`, ...). Requests without those markers pass through untouched.

### Tests

- non-codex prompts pass through unchanged
- codex prompts are still cleaned
- no system message => passthrough