### PR TITLE
v1.4.8: adopt official CLI request-header fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,9 +358,25 @@ curl http://127.0.0.1:8787/v1/chat/completions \
 | `CB_GATEWAY_CORS_ORIGINS` | 允许的浏览器来源，逗号分隔，默认仅本机来源 |
 | `CB_GATEWAY_ALLOW_UNAUTHENTICATED_API` | 设为 `1` 时允许未创建 API Key 的业务请求，默认关闭 |
 | `CB_GATEWAY_SECURE_COOKIE` | 设为 `1` 时强制管理 Cookie 使用 Secure 标记 |
+| `CB_GATEWAY_USER_AGENT` | 出站请求完整 User-Agent；默认官方 CLI 指纹 `CLI/2.109.2 CodeBuddy/2.109.2`，可设回 `codebuddy2openai/2.0` 回退历史 UA |
+| `CB_GATEWAY_IDE_VERSION` | 官方指纹中的 CLI 版本号，默认 `2.109.2` |
+| `CB_GATEWAY_STAINLESS_OS` | 官方指纹上报的操作系统，默认按当前平台推断 |
+| `CB_GATEWAY_STAINLESS_PACKAGE_VERSION` | 官方 SDK 指纹版本号，默认 `5.10.1` |
+| `CB_GATEWAY_NODE_VERSION` | 官方 SDK 指纹 Node 运行时版本，默认 `v22.13.1` |
 | `CB_AUTH_DIR` | 指定 Work Buddy / CodeBuddy auth 文件目录 |
 | `CB_HOST_AUTH_DIR` | Docker 启动脚本使用的宿主机 auth 目录 |
 | `CB_CONTAINER_AUTH_DIR` | Docker 容器内 auth 挂载目录，默认 `/auth` |
+
+## 官方请求头指纹
+
+转发到上游的请求默认携带 Work Buddy / CodeBuddy 官方 CLI 客户端的完整请求头指纹（见 `fingerprint.py`），与官方客户端的出站请求保持一致：
+
+- **通用头**：`X-Requested-With: XMLHttpRequest`、按账号域选择的 `Origin` / `Referer`（`www.codebuddy.cn` 或 `www.workbuddy.ai`）、`X-Product: SaaS`、`X-Domain`，以及 `X-Request-ID` / `X-B3-*` / `b3` 分布式追踪头。
+- **Chat 头**：`Authorization: Bearer`、`X-User-Id`、`X-Enterprise-Id`、`X-Tenant-Id`、`X-IDE-Type/Name/Version`、`x-codebuddy-request: 1`、`X-Agent-Intent: craft`、每请求生成的 `X-Conversation-*`，以及官方 SDK 的 `x-stainless-*` 指纹头。
+- **Billing 头**：余额 / 积分接口使用精简指纹（`Authorization`、`X-User-Id`、`X-Enterprise-Id`、`X-Tenant-Id`、`X-Domain`）。
+- **Refresh 头**：`X-Refresh-Token` 只出现在 token 刷新接口，chat 请求绝不携带。
+
+字段缺失时按官方 CLI 约定发送 `X-No-*` 标记（如 `X-No-User-Id: 1`），而不是空值。以上均可用 `CB_GATEWAY_USER_AGENT` 等环境变量覆盖（见上表）。指纹只作用于请求头；如上游进一步校验 TLS 指纹（JA3），需要额外部署支持 TLS 指纹模拟的转发层。
 
 ## 数据和安全
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -358,9 +358,25 @@ curl http://127.0.0.1:8787/v1/chat/completions \
 | `CB_GATEWAY_CORS_ORIGINS` | Comma-separated browser origin allowlist; local origins by default |
 | `CB_GATEWAY_ALLOW_UNAUTHENTICATED_API` | Set to `1` to allow API calls before creating a key; disabled by default |
 | `CB_GATEWAY_SECURE_COOKIE` | Set to `1` to force the Secure flag on the admin cookie |
+| `CB_GATEWAY_USER_AGENT` | Full outgoing User-Agent; defaults to the official CLI fingerprint `CLI/2.109.2 CodeBuddy/2.109.2`; set `codebuddy2openai/2.0` to revert to the historical UA |
+| `CB_GATEWAY_IDE_VERSION` | CLI version used in the official fingerprint, default `2.109.2` |
+| `CB_GATEWAY_STAINLESS_OS` | OS reported by the official fingerprint; inferred from the current platform by default |
+| `CB_GATEWAY_STAINLESS_PACKAGE_VERSION` | Official SDK fingerprint package version, default `5.10.1` |
+| `CB_GATEWAY_NODE_VERSION` | Official SDK fingerprint Node runtime version, default `v22.13.1` |
 | `CB_AUTH_DIR` | Work Buddy / CodeBuddy auth file directory |
 | `CB_HOST_AUTH_DIR` | Host auth directory used by Docker helper scripts |
 | `CB_CONTAINER_AUTH_DIR` | Auth mount directory inside Docker, default `/auth` |
+
+## Official request fingerprint
+
+Upstream requests carry the full request-header fingerprint of the official Work Buddy / CodeBuddy CLI client (see `fingerprint.py`), matching the official client's outgoing requests:
+
+- **Common**: `X-Requested-With: XMLHttpRequest`, region-aware `Origin` / `Referer` (`www.codebuddy.cn` or `www.workbuddy.ai`), `X-Product: SaaS`, `X-Domain`, plus `X-Request-ID` / `X-B3-*` / `b3` trace headers.
+- **Chat**: `Authorization: Bearer`, `X-User-Id`, `X-Enterprise-Id`, `X-Tenant-Id`, `X-IDE-Type/Name/Version`, `x-codebuddy-request: 1`, `X-Agent-Intent: craft`, per-request `X-Conversation-*`, and the official SDK `x-stainless-*` headers.
+- **Billing**: balance / check-in endpoints use a lean fingerprint (`Authorization`, `X-User-Id`, `X-Enterprise-Id`, `X-Tenant-Id`, `X-Domain`).
+- **Refresh**: `X-Refresh-Token` only ever appears on the token-refresh endpoint, never on chat requests.
+
+Missing fields follow the official CLI convention of `X-No-*` markers (e.g. `X-No-User-Id: 1`) instead of empty values. Everything can be overridden with `CB_GATEWAY_USER_AGENT` and the other variables listed above. The fingerprint covers request headers only; if the upstream also validates TLS fingerprints (JA3), an additional TLS-impersonation forwarding layer would be required.
 
 ## Data and Security
 

--- a/auth_manager.py
+++ b/auth_manager.py
@@ -22,13 +22,15 @@ from typing import Optional
 import httpx
 
 import database as db
+import fingerprint
 
 BACKEND = "https://copilot.tencent.com"
 DEFAULT_DOMAIN = "www.codebuddy.cn"
 
-# 协议逆向文档记录的历史 UA。可按需用 CB_GATEWAY_USER_AGENT 覆盖。
-_DEFAULT_USER_AGENT = "codebuddy2openai/2.0"
-USER_AGENT = os.environ.get("CB_GATEWAY_USER_AGENT") or _DEFAULT_USER_AGENT
+# 官方 Work Buddy / CodeBuddy CLI 客户端指纹（见 fingerprint.py）。
+# 兼容保留 CB_GATEWAY_USER_AGENT 覆盖；如上游不接受新 UA，
+# 设 CB_GATEWAY_USER_AGENT=codebuddy2openai/2.0 可回退到历史 UA。
+USER_AGENT = fingerprint.user_agent()
 
 _lock = threading.Lock()
 _token_locks: dict[int, asyncio.Lock] = {}
@@ -345,9 +347,7 @@ async def refresh_token(account: dict) -> bool:
     aid = account["id"]
     lock = _get_token_lock(aid)
     async with lock:
-        headers = build_headers(account)
-        headers["X-Refresh-Token"] = account.get("refresh_token", "")
-        headers["X-Auth-Refresh-Source"] = "plugin"
+        headers = build_refresh_headers(account)
         url = f"{backend_url()}/v2/plugin/auth/token/refresh"
 
         try:
@@ -402,22 +402,31 @@ async def ensure_token_valid(account: dict) -> bool:
 # Header 构造
 # ============================================================
 
+def _fingerprint_account(account: dict) -> dict:
+    """为指纹构造补齐默认 domain（不修改原 dict）。"""
+    if (account.get("domain") or "").strip():
+        return account
+    domain = str(db.get_setting("default_domain", DEFAULT_DOMAIN) or DEFAULT_DOMAIN)
+    return {**account, "domain": domain}
+
+
 def build_headers(account: dict) -> dict:
-    domain = account.get("domain") or str(db.get_setting("default_domain", DEFAULT_DOMAIN) or DEFAULT_DOMAIN)
-    return {
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "Authorization": f"Bearer {account.get('access_token', '')}",
-        "X-User-Id": account.get("uid", ""),
-        "X-Enterprise-Id": account.get("enterprise_id", ""),
-        "X-Tenant-Id": account.get("enterprise_id", ""),
-        "X-Domain": domain,
-        "User-Agent": USER_AGENT,
-    }
+    """Chat 请求头：官方 CLI 完整指纹（通用 + 账号 + IDE/CLI + SDK）。"""
+    return fingerprint.chat_headers(_fingerprint_account(account))
+
+
+def build_billing_headers(account: dict) -> dict:
+    """Billing 接口（余额/积分）请求头指纹。"""
+    return fingerprint.billing_headers(_fingerprint_account(account))
+
+
+def build_refresh_headers(account: dict) -> dict:
+    """Token 刷新接口请求头指纹（X-Refresh-Token 只出现在这里）。"""
+    return fingerprint.refresh_headers(_fingerprint_account(account))
 
 
 async def get_valid_headers(account: dict) -> Optional[dict]:
-    """确保 token 有效后返回 header。失败返回 None。"""
+    """确保 token 有效后返回 chat 指纹 header。失败返回 None。"""
     if not await ensure_token_valid(account):
         return None
     # 重新从数据库读取最新凭据
@@ -425,6 +434,17 @@ async def get_valid_headers(account: dict) -> Optional[dict]:
     if not fresh:
         return None
     return build_headers(fresh)
+
+
+async def get_billing_headers(account: dict) -> Optional[dict]:
+    """确保 token 有效后返回 billing 指纹 header。失败返回 None。"""
+    if not await ensure_token_valid(account):
+        return None
+    # 重新从数据库读取最新凭据
+    fresh = db.get_account(account["id"])
+    if not fresh:
+        return None
+    return build_billing_headers(fresh)
 
 
 # ============================================================
@@ -634,7 +654,7 @@ async def fetch_account_resources(
             cached["stale"] = False
             return cached
 
-    headers = await get_valid_headers(account)
+    headers = await get_billing_headers(account)
     if not headers:
         return _resource_failure(
             account,
@@ -756,7 +776,7 @@ async def fetch_checkin_status(
             cached["stale"] = False
             return cached
 
-    headers = await get_valid_headers(account)
+    headers = await get_billing_headers(account)
     if not headers:
         return _checkin_failure(
             account,
@@ -810,7 +830,7 @@ async def claim_daily_checkin(account: dict) -> dict:
     fresh = db.get_account(account["id"])
     if not fresh:
         return _checkin_result(account, ok=False, message="account not found")
-    headers = await get_valid_headers(fresh)
+    headers = await get_billing_headers(fresh)
     if not headers:
         return _checkin_result(
             account,

--- a/docs/releases/v1.4.8.md
+++ b/docs/releases/v1.4.8.md
@@ -1,0 +1,11 @@
+# Buddy2api v1.4.8
+
+发布日期：2026-08-19
+
+- 实现 Work Buddy / CodeBuddy 官方 CLI 客户端请求头指纹模拟：chat、billing、token 刷新三类上游请求统一携带官方客户端指纹头。
+- 可通过 `CB_GATEWAY_USER_AGENT` 等环境变量自定义或回退。
+
+## 兼容与升级说明
+
+- 无数据库结构变更，无迁移动作。
+- Docker 用户重新构建并重启服务。

--- a/fingerprint.py
+++ b/fingerprint.py
@@ -1,0 +1,198 @@
+"""
+fingerprint.py — Work Buddy / CodeBuddy 官方客户端请求头指纹模拟
+
+综合 fingerprint-refs 中四份逆向参考实现的共识字段构建，让出站请求与
+官方 CLI 客户端（CLI/x.y CodeBuddy/x.y）在请求头层面保持一致：
+
+  - workbuddy2api_sliv（Go）：common / chat / billing / refresh 头规范、
+    Origin/Referer 地域规则、X-No-* 缺省字段约定
+  - workbuddy2api_wug（TS）：X-IDE-Type/Name/Version、x-codebuddy-request、X-Product
+  - workbuddy2api_orange（TS）：X-B3-* / b3 分布式追踪头、X-Agent-Intent、
+    X-Conversation-ID / X-Conversation-Request-ID / X-Conversation-Message-ID
+  - workbuddy2api_xue（Python）：x-stainless-* SDK 指纹头
+
+可用环境变量覆盖（默认值均为逆向捕获到的官方值）：
+
+  CB_GATEWAY_USER_AGENT                 完整 User-Agent，默认 CLI/<v> CodeBuddy/<v>
+  CB_GATEWAY_IDE_VERSION                CLI 版本号，默认 2.109.2
+  CB_GATEWAY_STAINLESS_OS               上报的操作系统，默认按当前平台推断
+  CB_GATEWAY_STAINLESS_PACKAGE_VERSION  x-stainless-package-version，默认 5.10.1
+  CB_GATEWAY_NODE_VERSION               x-stainless-runtime-version，默认 v22.13.1
+"""
+
+import os
+import platform
+import secrets
+import uuid
+from typing import Optional
+
+DEFAULT_IDE_VERSION = "2.109.2"
+
+_CN_ORIGIN = "https://www.codebuddy.cn"
+_GLOBAL_ORIGIN = "https://www.workbuddy.ai"
+
+STAINLESS_PACKAGE_VERSION = os.environ.get(
+    "CB_GATEWAY_STAINLESS_PACKAGE_VERSION", "5.10.1"
+)
+NODE_RUNTIME_VERSION = os.environ.get("CB_GATEWAY_NODE_VERSION", "v22.13.1")
+
+
+def ide_version() -> str:
+    """CLI 版本号，驱动 User-Agent 与 X-IDE-Version。"""
+    return (os.environ.get("CB_GATEWAY_IDE_VERSION") or "").strip() or DEFAULT_IDE_VERSION
+
+
+def user_agent() -> str:
+    """官方 CLI User-Agent。可用 CB_GATEWAY_USER_AGENT 整体覆盖。"""
+    override = (os.environ.get("CB_GATEWAY_USER_AGENT") or "").strip()
+    if override:
+        return override
+    v = ide_version()
+    return f"CLI/{v} CodeBuddy/{v}"
+
+
+def stainless_os() -> str:
+    """官方 CLI 上报的操作系统。默认按当前平台推断。"""
+    override = (os.environ.get("CB_GATEWAY_STAINLESS_OS") or "").strip()
+    if override:
+        return override
+    system = platform.system()
+    if system == "Windows":
+        return "Windows"
+    if system == "Darwin":
+        return "macOS"
+    return "Linux"
+
+
+def origin_for(domain: str) -> str:
+    """按账号域选择 Origin/Referer：workbuddy.ai 国际版，否则中国版。"""
+    if "workbuddy" in (domain or "").lower():
+        return _GLOBAL_ORIGIN
+    return _CN_ORIGIN
+
+
+def _trace_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _span_id() -> str:
+    return secrets.token_hex(8)
+
+
+def _domain_headers(account: dict) -> dict:
+    domain = (account.get("domain") or "").strip()
+    if domain:
+        return {"X-Domain": domain}
+    # 与官方 CLI 一致：字段缺失时用 X-No-* 标记，而不是发空值
+    return {"X-No-Department-Info": "1"}
+
+
+def _account_header(account: dict, field: str, header: str, no_header: str) -> dict:
+    value = str(account.get(field) or "").strip()
+    if value:
+        return {header: value}
+    return {no_header: "1"}
+
+
+def common_headers(account: dict) -> dict:
+    """所有 API 共享的通用指纹头（含 B3 追踪头）。"""
+    domain = (account.get("domain") or "").strip()
+    origin = origin_for(domain)
+    request_id = _trace_id()
+    span_id = _span_id()
+    return {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/plain, */*",
+        "X-Requested-With": "XMLHttpRequest",
+        "Origin": origin,
+        "Referer": origin + "/",
+        "X-Product": "SaaS",
+        "User-Agent": user_agent(),
+        "X-Request-ID": request_id,
+        "X-B3-TraceId": request_id,
+        "X-B3-SpanId": span_id,
+        "X-B3-Sampled": "1",
+        "b3": f"{request_id}-{span_id}-1-",
+        **_domain_headers(account),
+    }
+
+
+def chat_headers(account: dict) -> dict:
+    """Chat 请求头：通用指纹 + 账号头 + IDE/CLI 指纹 + SDK 指纹。
+
+    安全红线：chat 请求绝不携带 X-Refresh-Token。
+    """
+    headers = common_headers(account)
+    headers.update(_account_header(account, "access_token", "Authorization", "X-No-Authorization"))
+    headers.update(_account_header(account, "uid", "X-User-Id", "X-No-User-Id"))
+    headers.update(
+        _account_header(account, "enterprise_id", "X-Enterprise-Id", "X-No-Enterprise-Id")
+    )
+    if headers.get("Authorization"):
+        headers["Authorization"] = f"Bearer {headers['Authorization']}"
+    enterprise_id = str(account.get("enterprise_id") or "").strip()
+    if enterprise_id:
+        headers["X-Tenant-Id"] = enterprise_id
+
+    v = ide_version()
+    headers.update(
+        {
+            "X-IDE-Type": "CLI",
+            "X-IDE-Name": "CLI",
+            "X-IDE-Version": v,
+            "x-codebuddy-request": "1",
+            "X-Agent-Intent": "craft",
+            # 无状态网关按官方 CLI 规则为每次请求生成全新会话标识
+            "X-Conversation-ID": str(uuid.uuid4()),
+            "X-Conversation-Request-ID": uuid.uuid4().hex,
+            "X-Conversation-Message-ID": uuid.uuid4().hex,
+            "x-stainless-arch": "x64",
+            "x-stainless-lang": "js",
+            "x-stainless-os": stainless_os(),
+            "x-stainless-package-version": STAINLESS_PACKAGE_VERSION,
+            "x-stainless-retry-count": "0",
+            "x-stainless-runtime": "node",
+            "x-stainless-runtime-version": NODE_RUNTIME_VERSION,
+        }
+    )
+    return headers
+
+
+def billing_headers(account: dict) -> dict:
+    """Billing 接口（余额/积分）请求头指纹。"""
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-Product": "SaaS",
+        "User-Agent": user_agent(),
+        **_domain_headers(account),
+    }
+    headers.update(_account_header(account, "access_token", "Authorization", "X-No-Authorization"))
+    if headers.get("Authorization"):
+        headers["Authorization"] = f"Bearer {headers['Authorization']}"
+    headers.update(_account_header(account, "uid", "X-User-Id", "X-No-User-Id"))
+    headers.update(
+        _account_header(account, "enterprise_id", "X-Enterprise-Id", "X-No-Enterprise-Id")
+    )
+    enterprise_id = str(account.get("enterprise_id") or "").strip()
+    if enterprise_id:
+        headers["X-Tenant-Id"] = enterprise_id
+    return headers
+
+
+def refresh_headers(account: dict) -> dict:
+    """Token 刷新接口请求头。X-Refresh-Token 只允许出现在这里。"""
+    headers = common_headers(account)
+    headers["Accept"] = "application/json"
+    headers["Cache-Control"] = "no-cache"
+    headers["Pragma"] = "no-cache"
+    access_token = str(account.get("access_token") or "").strip()
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+    headers["X-Refresh-Token"] = str(account.get("refresh_token") or "")
+    headers["X-Auth-Refresh-Source"] = "plugin"
+    headers.update(_account_header(account, "uid", "X-User-Id", "X-No-User-Id"))
+    headers.update(
+        _account_header(account, "enterprise_id", "X-Enterprise-Id", "X-No-Enterprise-Id")
+    )
+    return headers

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.4.7"
+VERSION = "1.4.8"


### PR DESCRIPTION
实现 Work Buddy / CodeBuddy 官方 CLI 客户端请求头指纹模拟，出站请求统一携带官方客户端指纹头。详见 docs/releases/v1.4.8.md。