### PR TITLE
v1.4.9: fix agent tool-loop stalls (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ curl http://127.0.0.1:8787/v1/chat/completions \
 | `CB_GATEWAY_STAINLESS_OS` | 官方指纹上报的操作系统，默认按当前平台推断 |
 | `CB_GATEWAY_STAINLESS_PACKAGE_VERSION` | 官方 SDK 指纹版本号，默认 `5.10.1` |
 | `CB_GATEWAY_NODE_VERSION` | 官方 SDK 指纹 Node 运行时版本，默认 `v22.13.1` |
+| `CB_GATEWAY_TOOL_STALL_RETRY` | 非流式请求遇到"工具停转"时自动用 `tool_choice=required` 重试一次，默认开启，设 `0` 关闭 |
+| `CB_GATEWAY_TOOL_STALL_FAIL_STREAM` | 流式请求遇到"工具停转"时把该回合标记为失败（让 DSH / OpenCode 等客户端自动重试），默认关闭 |
 | `CB_AUTH_DIR` | 指定 Work Buddy / CodeBuddy auth 文件目录 |
 | `CB_HOST_AUTH_DIR` | Docker 启动脚本使用的宿主机 auth 目录 |
 | `CB_CONTAINER_AUTH_DIR` | Docker 容器内 auth 挂载目录，默认 `/auth` |
@@ -377,6 +379,15 @@ curl http://127.0.0.1:8787/v1/chat/completions \
 - **Refresh 头**：`X-Refresh-Token` 只出现在 token 刷新接口，chat 请求绝不携带。
 
 字段缺失时按官方 CLI 约定发送 `X-No-*` 标记（如 `X-No-User-Id: 1`），而不是空值。以上均可用 `CB_GATEWAY_USER_AGENT` 等环境变量覆盖（见上表）。指纹只作用于请求头；如上游进一步校验 TLS 指纹（JA3），需要额外部署支持 TLS 指纹模拟的转发层。
+
+## 工具停转防护（issue #31）
+
+上游模型在 agent 工具循环回合（请求带 tools 且历史含工具结果）偶尔会以 `stop` + 纯文本结束而不调用任何工具（例如回复"好的，马上继续跑流程"），导致 agent 工作流卡成纯聊天。网关现在会检测这种"工具停转"：
+
+- **非流式**：自动用 `tool_choice=required` 重试一次；重试产出工具调用则采用重试结果，否则保留首次文字回复。默认开启，可用 `CB_GATEWAY_TOOL_STALL_RETRY=0` 关闭。
+- **流式**：默认原样透传但后台日志标记为 `tool_stall`；设置 `CB_GATEWAY_TOOL_STALL_FAIL_STREAM=1` 时把该回合标记为失败，让有重试机制的客户端（DSH / OpenCode）自动重试。
+
+判定条件限定为工具循环回合且回复是"确认式话术"（如"好的，马上继续…"），总结类回答不受影响。转换层丢弃后端不支持的请求工具类型（如 `web_search`）时会记录日志，便于诊断模型"因缺少工具而用文字代替"的退化。
 
 ## 数据和安全
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -363,6 +363,8 @@ curl http://127.0.0.1:8787/v1/chat/completions \
 | `CB_GATEWAY_STAINLESS_OS` | OS reported by the official fingerprint; inferred from the current platform by default |
 | `CB_GATEWAY_STAINLESS_PACKAGE_VERSION` | Official SDK fingerprint package version, default `5.10.1` |
 | `CB_GATEWAY_NODE_VERSION` | Official SDK fingerprint Node runtime version, default `v22.13.1` |
+| `CB_GATEWAY_TOOL_STALL_RETRY` | Auto-retry non-streaming "tool stall" turns once with `tool_choice=required`; enabled by default, set `0` to disable |
+| `CB_GATEWAY_TOOL_STALL_FAIL_STREAM` | Mark streaming "tool stall" turns as failed so retrying clients (DSH / OpenCode) retry automatically; disabled by default |
 | `CB_AUTH_DIR` | Work Buddy / CodeBuddy auth file directory |
 | `CB_HOST_AUTH_DIR` | Host auth directory used by Docker helper scripts |
 | `CB_CONTAINER_AUTH_DIR` | Auth mount directory inside Docker, default `/auth` |
@@ -377,6 +379,15 @@ Upstream requests carry the full request-header fingerprint of the official Work
 - **Refresh**: `X-Refresh-Token` only ever appears on the token-refresh endpoint, never on chat requests.
 
 Missing fields follow the official CLI convention of `X-No-*` markers (e.g. `X-No-User-Id: 1`) instead of empty values. Everything can be overridden with `CB_GATEWAY_USER_AGENT` and the other variables listed above. The fingerprint covers request headers only; if the upstream also validates TLS fingerprints (JA3), an additional TLS-impersonation forwarding layer would be required.
+
+## Tool-stall protection (issue #31)
+
+On agent tool-loop turns (request has `tools` and tool results in history), the upstream model occasionally ends with `stop` plus plain text instead of calling a tool (e.g. "OK, I'll continue right away"), which stalls agent workflows. The gateway now detects this "tool stall":
+
+- **Non-streaming**: retries once automatically with `tool_choice=required`; the retry result is used when it contains tool calls, otherwise the first text reply is kept. Enabled by default; set `CB_GATEWAY_TOOL_STALL_RETRY=0` to disable.
+- **Streaming**: passed through by default, with the turn logged as `tool_stall`; set `CB_GATEWAY_TOOL_STALL_FAIL_STREAM=1` to mark the turn as failed so clients with retry logic (DSH / OpenCode) retry automatically.
+
+Detection is limited to tool-loop turns with acknowledgment-style replies (e.g. "OK, I'll continue..."); summary answers are unaffected. Dropped unsupported request tool types (e.g. `web_search`) are logged to help diagnose text-instead-of-tool degradation.
 
 ## Data and Security
 

--- a/docs/releases/v1.4.9.md
+++ b/docs/releases/v1.4.9.md
@@ -1,0 +1,12 @@
+# Buddy2api v1.4.9
+
+发布日期：2026-08-19
+
+- 修复 agent 工具循环回合的"工具停转"（issue #31）：上游模型以 `stop` + 纯文本结束而未调用工具时，非流式请求自动以 `tool_choice=required` 重试一次；流式请求默认记录 `tool_stall` 标记，可选标记为失败让客户端自动重试。
+- 转换层丢弃后端不支持的请求工具类型时记录日志，便于诊断。
+
+## 兼容与升级说明
+
+- 无数据库结构变更，无迁移动作。
+- 新增环境变量 `CB_GATEWAY_TOOL_STALL_RETRY`（默认 `1`）、`CB_GATEWAY_TOOL_STALL_FAIL_STREAM`（默认 `0`）。
+- Docker 用户重新构建并重启服务。

--- a/proxy.py
+++ b/proxy.py
@@ -42,6 +42,62 @@ def _looks_like_audit_block(text: str) -> bool:
     return any(p in text for p in _AUDIT_PHRASES)
 
 
+# 工具停转（tool stall）检测与修复开关。
+# 场景：agent 工具循环回合（请求带 tools 且历史含 role=tool），上游模型却以
+# finish_reason=stop + 纯文本（"好的，马上继续跑流程"式确认话术）结束且未调用
+# 任何工具 —— 工作流卡死成纯聊天（issue #31）。
+TOOL_STALL_RETRY = (
+    os.environ.get("CB_GATEWAY_TOOL_STALL_RETRY", "1").strip().lower()
+    not in {"0", "false", "no", "off"}
+)
+TOOL_STALL_FAIL_STREAM = (
+    os.environ.get("CB_GATEWAY_TOOL_STALL_FAIL_STREAM", "0").strip().lower()
+    in {"1", "true", "yes", "on"}
+)
+
+_STALL_POSITIVE_MARKERS = (
+    "马上继续", "继续跑", "接下来需要", "请问您接下来",
+    "这就去", "马上开始", "我现在就", "这就开始", "稍等",
+)
+_STALL_NEGATIVE_MARKERS = (
+    "总结", "已完成", "结果如下", "以下是", "以上就是", "完成情况",
+)
+
+
+def _request_has_tool_loop(body: dict) -> bool:
+    """是否为 agent 工具循环回合：声明了 tools 且历史里存在工具结果。"""
+    if not isinstance(body.get("tools"), list) or not body["tools"]:
+        return False
+    return any(
+        isinstance(msg, dict) and msg.get("role") == "tool"
+        for msg in (body.get("messages") or [])
+    )
+
+
+def _looks_like_stall_text(text: str) -> bool:
+    """空内容视为 stall；否则要求短文本且像'知道了，马上继续'式话术，
+    排除总结性回答。"""
+    text = (text or "").strip()
+    if not text:
+        return True
+    if len(text) > 160:
+        return False
+    if any(marker in text for marker in _STALL_NEGATIVE_MARKERS):
+        return False
+    return any(marker in text for marker in _STALL_POSITIVE_MARKERS)
+
+
+def _is_tool_stall(body: dict, finish_reason, tool_calls: bool, text: str) -> bool:
+    """判定一次上游完成是否属于工具停转（stall）。"""
+    if not _request_has_tool_loop(body):
+        return False
+    if tool_calls:
+        return False
+    if (finish_reason or "stop") not in {"stop", None}:
+        return False
+    return _looks_like_stall_text(text)
+
+
 def _is_retryable_status(status: int) -> bool:
     return status in RETRYABLE_STATUS_CODES or status in {401, 403}
 
@@ -597,6 +653,28 @@ async def proxy_chat_completions(
         t0 = time.time()
         result = await _collect_stream(url, headers, body, account, api_key_info, model_name, t0)
         if result[0] == "json":
+            # 工具停转修复：agent 回合被上游以 stop+纯文本结束且未调用工具时，
+            # 用 tool_choice=required 重试一次；重试产出工具调用则采用重试结果。
+            if TOOL_STALL_RETRY:
+                choice = (result[1].get("choices") or [{}])[0]
+                message = choice.get("message") or {}
+                if _is_tool_stall(
+                    body,
+                    choice.get("finish_reason"),
+                    bool(message.get("tool_calls")),
+                    message.get("content") or "",
+                ):
+                    retry_body = {**body, "tool_choice": "required"}
+                    retry_t0 = time.time()
+                    retry_result = await _collect_stream(
+                        url, headers, retry_body, account, api_key_info, model_name, retry_t0
+                    )
+                    if retry_result[0] == "json":
+                        retry_choice = (retry_result[1].get("choices") or [{}])[0]
+                        retry_message = retry_choice.get("message") or {}
+                        if retry_message.get("tool_calls"):
+                            auth_manager.mark_account_success(account["id"])
+                            return retry_result
             auth_manager.mark_account_success(account["id"])
             return result
 
@@ -888,8 +966,13 @@ async def _stream_upstream(
         full_text = "".join(observer.content_parts)
         audit_blocked = _looks_like_audit_block(full_text)
         finish_reason = next((reason for reason in observer.finish_reasons.values() if reason), None)
-        log_finish = "content_filter" if audit_blocked else (finish_reason or "stop")
-        log_error = ("[audit blocked] " + full_text[:300]) if audit_blocked else ""
+        tool_stall = _is_tool_stall(body, finish_reason, bool(observer.tool_call_choices), full_text)
+        log_finish = "content_filter" if audit_blocked else ("tool_stall" if tool_stall else (finish_reason or "stop"))
+        log_error = (
+            ("[audit blocked] " + full_text[:300]) if audit_blocked
+            else ("[tool stall] " + full_text[:300]) if tool_stall
+            else ""
+        )
         _log_request(
             api_key_info, account, model_name, True,
             observer.usage.get("prompt_tokens", 0),
@@ -898,6 +981,18 @@ async def _stream_upstream(
             observer.usage.get("credit", 0),
             log_finish, 200, log_error, t0,
         )
+        if tool_stall and TOOL_STALL_FAIL_STREAM:
+            # 流式已发出文本增量，无法回退重试；把本回合标记为失败，
+            # 让有重试机制的客户端（DSH / OpenCode 等）自动重试。
+            yield _json_sse_event({
+                "error": {
+                    "message": "The model finished a tool turn without calling a tool.",
+                    "type": "upstream_error",
+                    "code": "upstream_tool_stall",
+                },
+            })
+            yield b"data: [DONE]\n\n"
+            return
         for event in pending_terminal_events:
             yield event
         if synthetic_terminal is not None:

--- a/responses.py
+++ b/responses.py
@@ -9,6 +9,7 @@ Codex 从 2026.2 起强制要求 wire_api="responses"，不再支持 chat/comple
 import json
 import os
 import re
+import sys
 import time
 from pathlib import Path
 from typing import AsyncGenerator, Optional
@@ -196,7 +197,15 @@ def responses_to_chat(resp_payload: dict) -> dict:
                     "strict": t.get("strict"),
                 },
             })
-        # web_search, file_search, code_interpreter 等跳过（后端不支持）
+        else:
+            # web_search, file_search, code_interpreter 等后端不支持：跳过，
+            # 但记录日志，便于诊断"模型因缺少工具而用文字代替"的退化（issue #31）。
+            print(
+                "[responses] dropping unsupported tool type "
+                f"{t.get('type')!r}"
+                + (f" name={t.get('name')!r}" if t.get('name') else ""),
+                file=sys.stderr,
+            )
 
     # tool_choice
     tool_choice = resp_payload.get("tool_choice")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2076,3 +2076,219 @@ def test_codex_sanitize_passthrough_without_system_prompt():
     payload = {"model": "auto", "messages": [{"role": "user", "content": "hello"}]}
     out = responses.apply_codex_sanitize(dict(payload))
     assert out == payload
+
+
+# ============================================================
+# 工具停转（tool stall）检测与修复 — issue #31
+# ============================================================
+
+def _tool_loop_body():
+    return {
+        "model": "auto",
+        "stream": False,
+        "tools": [{"type": "function", "function": {"name": "list_files", "parameters": {"type": "object"}}}],
+        "messages": [
+            {"role": "user", "content": "列出文件"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "list_files", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "a.txt"},
+            {"role": "user", "content": "继续跑流程。"},
+        ],
+    }
+
+
+def test_stall_detection_ack_text():
+    body = _tool_loop_body()
+    assert proxy._request_has_tool_loop(body)
+    assert proxy._looks_like_stall_text("好的，马上继续跑流程。")
+    assert proxy._is_tool_stall(body, "stop", False, "好的，马上继续跑流程。")
+
+
+def test_stall_detection_rejects_summary():
+    body = _tool_loop_body()
+    assert not proxy._looks_like_stall_text("任务完成，总结如下：共处理 3 个文件。")
+    assert not proxy._is_tool_stall(body, "stop", False, "任务完成，总结如下：共处理 3 个文件。")
+
+
+def test_stall_detection_requires_tool_loop_and_tools():
+    no_tool_history = {
+        "model": "auto",
+        "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        "messages": [{"role": "user", "content": "继续。"}],
+    }
+    assert not proxy._request_has_tool_loop(no_tool_history)
+    assert not proxy._is_tool_stall(no_tool_history, "stop", False, "好的，马上继续。")
+    no_tools = {
+        "model": "auto",
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None, "tool_calls": []},
+            {"role": "tool", "tool_call_id": "x", "content": "y"},
+            {"role": "user", "content": "继续。"},
+        ],
+    }
+    assert not proxy._is_tool_stall(no_tools, "stop", False, "好的，马上继续。")
+    assert not proxy._is_tool_stall(_tool_loop_body(), "stop", True, "好的，马上继续。")
+    assert not proxy._is_tool_stall(_tool_loop_body(), "length", False, "好的，马上继续。")
+
+
+def test_stall_retry_nonstream_uses_tool_call_result(monkeypatch, isolated_db):
+    """停转时自动以 tool_choice=required 重试，并优先采用重试出的工具调用结果。"""
+    stall_json = {
+        "id": "c1", "object": "chat.completion", "created": 1,
+        "model": "auto",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "好的，马上继续跑流程。"},
+                     "finish_reason": "stop"}],
+        "usage": {},
+    }
+    fixed_json = {
+        "id": "c2", "object": "chat.completion", "created": 2,
+        "model": "auto",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "t1", "type": "function", "function": {"name": "list_files", "arguments": "{}"}}]},
+                     "finish_reason": "tool_calls"}],
+        "usage": {},
+    }
+
+    calls = []
+
+    account = {"id": 1, "name": "test-account"}
+
+    async def pick_account(_excluded):
+        return account
+
+    async def valid_headers(_account):
+        return {"Authorization": "Bearer test"}
+
+    async def fake_collect(url, headers, body, account, api_key_info, model_name, t0):
+        calls.append(body.get("tool_choice"))
+        if len(calls) == 1:
+            return ("json", stall_json)
+        return ("json", fixed_json)
+
+    monkeypatch.setattr(proxy, "_collect_stream", fake_collect)
+    monkeypatch.setattr(auth_manager, "pick_account_with_fallback", pick_account)
+    monkeypatch.setattr(auth_manager, "get_valid_headers", valid_headers)
+    monkeypatch.setattr(auth_manager, "mark_account_success", lambda _id: None)
+    monkeypatch.setattr(auth_manager, "mark_account_failure", lambda *_a: None)
+    monkeypatch.setattr(auth_manager, "backend_url", lambda: "https://upstream.test")
+    monkeypatch.setattr(auth_manager, "request_timeout", lambda _default: 30)
+
+    async def run():
+        return await proxy.proxy_chat_completions(_tool_loop_body(), None)
+
+    result = asyncio.run(run())
+    assert result[0] == "json"
+    assert result[1]["choices"][0]["message"].get("tool_calls")
+    assert calls == [None, "required"]
+
+
+def test_stall_retry_nonstream_keeps_first_answer_when_retry_has_no_tools(monkeypatch, isolated_db):
+    """重试仍无工具调用时，保留首次的文字回复（例如总结类回答）。"""
+    stall_json = {
+        "id": "c1", "object": "chat.completion", "created": 1,
+        "model": "auto",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "好的，马上继续。"},
+                     "finish_reason": "stop"}],
+        "usage": {},
+    }
+    again_json = {
+        "id": "c2", "object": "chat.completion", "created": 2,
+        "model": "auto",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "好的，马上继续。"},
+                     "finish_reason": "stop"}],
+        "usage": {},
+    }
+
+    calls = []
+
+    account = {"id": 1, "name": "test-account"}
+
+    async def pick_account(_excluded):
+        return account
+
+    async def valid_headers(_account):
+        return {"Authorization": "Bearer test"}
+
+    async def fake_collect(url, headers, body, account, api_key_info, model_name, t0):
+        calls.append(body.get("tool_choice"))
+        if len(calls) == 1:
+            return ("json", stall_json)
+        return ("json", again_json)
+
+    monkeypatch.setattr(proxy, "_collect_stream", fake_collect)
+    monkeypatch.setattr(auth_manager, "pick_account_with_fallback", pick_account)
+    monkeypatch.setattr(auth_manager, "get_valid_headers", valid_headers)
+    monkeypatch.setattr(auth_manager, "mark_account_success", lambda _id: None)
+    monkeypatch.setattr(auth_manager, "mark_account_failure", lambda *_a: None)
+    monkeypatch.setattr(auth_manager, "backend_url", lambda: "https://upstream.test")
+    monkeypatch.setattr(auth_manager, "request_timeout", lambda _default: 30)
+
+    async def run():
+        return await proxy.proxy_chat_completions(_tool_loop_body(), None)
+
+    result = asyncio.run(run())
+    assert result[0] == "json"
+    assert result[1]["choices"][0]["message"].get("content") == "好的，马上继续。"
+    assert calls == [None, "required"]
+
+
+def _stall_stream_chunks() -> list[bytes]:
+    """上游流：纯文本增量 + finish_reason=stop（无任何工具调用）。"""
+    return [
+        _chat_sse({
+            "id": "c1", "object": "chat.completion.chunk", "created": 1,
+            "choices": [{"index": 0, "delta": {"content": "好的，马上继续跑流程。"}, "finish_reason": None}],
+        }),
+        _chat_sse({
+            "id": "c1", "object": "chat.completion.chunk", "created": 1,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        }),
+        b"data: [DONE]\n\n",
+    ]
+
+
+def test_stream_tool_stall_fails_when_flag_on(monkeypatch, isolated_db):
+    """流式停转 + CB_GATEWAY_TOOL_STALL_FAIL_STREAM=1 → 回合标记为失败。"""
+    monkeypatch.setattr(proxy, "TOOL_STALL_FAIL_STREAM", True)
+    body = _tool_loop_body()
+    body["stream"] = True
+    raw = _collect_chat_proxy_stream(_stall_stream_chunks(), monkeypatch, body)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    assert done_count == 1
+    errors = [p for p in payloads if p.get("error")]
+    assert len(errors) == 1
+    assert errors[0]["error"]["code"] == "upstream_tool_stall"
+
+
+def test_stream_tool_stall_passthrough_when_flag_off(monkeypatch, isolated_db):
+    """默认（flag off）流式停转原样透传，仅日志标记 tool_stall。"""
+    body = _tool_loop_body()
+    body["stream"] = True
+    raw = _collect_chat_proxy_stream(_stall_stream_chunks(), monkeypatch, body)
+    payloads, done_count = _parse_chat_proxy_sse(raw)
+    assert done_count == 1
+    assert not any(p.get("error") for p in payloads)
+    assert any(p.get("choices") and p["choices"][0].get("finish_reason") == "stop" for p in payloads)
+
+
+def test_stream_tool_stall_is_logged(monkeypatch, isolated_db):
+    """流式停转（flag off）时日志 finish_reason 记为 tool_stall。"""
+    calls = _install_chat_account_stream_fakes(
+        monkeypatch,
+        [{"id": 1, "name": "test-account"}],
+        {1: _stall_stream_chunks()},
+    )
+    body = _tool_loop_body()
+    body["stream"] = True
+
+    async def collect():
+        return b"".join([
+            chunk
+            async for chunk in proxy._stream_upstream(body, None, "test-model")
+        ])
+
+    raw = asyncio.run(collect())
+    assert b"tool stall" not in raw
+    logged_finishes = [entry[0][8] for entry in calls["logs"]]
+    assert "tool_stall" in logged_finishes

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.4.8"
+VERSION = "1.4.9"


### PR DESCRIPTION
修复 agent 工具循环回合的工具停转（issue #31）：非流式自动重试、流式可选标记失败、丢弃工具打日志。详见 docs/releases/v1.4.9.md。