### PR TITLE
feat: add TraeWork channel (2.1.0)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 __pycache__/
 .pytest_cache/
 .pytest-tmp*/
+.pytest-temp*/
 *.pyc
 *.db
 *.db-wal

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 [English](README_EN.md) | 中文
 
-> 把本机已经登录的消费级 AI 客户端，接成 OpenAI 兼容接口，给 Codex、OpenCode、Cherry Studio、NextChat 等用。默认打开 Work Buddy / CodeBuddy、QClaw、千问办公（QwenWork）三个通道；管理页下拉选其中一个。一次请求只走一个通道。
+> 把本机已经登录的消费级 AI 客户端，接成 OpenAI 兼容接口，给 Codex、OpenCode、Cherry Studio、NextChat 等用。默认打开 Work Buddy / CodeBuddy、QClaw、千问办公（QwenWork）、TraeWork 四个通道；管理页下拉选其中一个。一次请求只走一个通道。
 
-当前版本 **2.0.1**。这个项目只适合本机自用，不要公开部署，也不要把登录凭据、API Key、数据库文件发给别人。
+当前版本 **2.1.0**。这个项目只适合本机自用，不要公开部署，也不要把登录凭据、API Key、数据库文件发给别人。
 
 ## 这是什么？
 
 Buddy2api 在本机提供 `http://127.0.0.1:8787/v1`。你在官方客户端里登录并且还有额度，这个网关把本机登录导入进来，把请求转到对应厂商。普通客户端走 Chat Completions；Codex 走 `/v1/responses`，管理页把 Key 类型选成 Codex 时会做一轮内容清洗。
 
-三个通道默认都开。没装、没登录的通道，账号页检测为空，不会自动入库。
+四个通道默认都开。没装、没登录的通道，账号页检测为空，不会自动入库。
 
 ```powershell
 python server.py
@@ -21,15 +21,16 @@ python server.py
 | WorkBuddy / CodeBuddy | 开 | `%LOCALAPPDATA%\CodeBuddyExtension\Data\Public\auth` |
 | QClaw | 开 | `%APPDATA%\QClaw` |
 | 千问办公 QwenWork | 开 | `%APPDATA%\QwenWorkCN` |
+| TraeWork | 开 | `%APPDATA%\TRAE SOLO CN\User\globalStorage` |
 
-路径不对时可用 `CB_AUTH_DIR`、`CB_QCLAW_AUTH_DIR`、`CB_QWENWORK_AUTH_DIR` 指定。三个通道的登录文件不要混在同一个目录。只要其中一家时，可设 `CB_GATEWAY_PROVIDERS=workbuddy` 收窄。
+路径不对时可用 `CB_AUTH_DIR`、`CB_QCLAW_AUTH_DIR`、`CB_QWENWORK_AUTH_DIR`、`CB_TRAEWORK_AUTH_DIR` 指定。四个通道的登录文件不要混在同一个目录。只要其中一家时，可设 `CB_GATEWAY_PROVIDERS=workbuddy` 收窄。
 
 ## 注意事项
 
 按下面「安装与启动」即可。这几条是 2.0 里最容易踩空的：
 
-1. **启动后账号页是空的，这是正常的。** 默认不再自动入库。到「账号」页：选通道 → 重新检测 → 一键导入。三个通道都能选。
-2. **一把 API Key 只打一个通道。** 创建时必须选通道。WorkBuddy 的 Key 发 `auto` / `glm-5.2`；QwenWork 的 Key 发 `auto` 或 `qwork-advanced`。通道和模型对不上会 400 或 403，不会帮你转到另一家。
+1. **启动后账号页是空的，这是正常的。** 默认不再自动入库。到「账号」页：选通道 → 重新检测 → 一键导入。四个通道都能选。
+2. **一把 API Key 只打一个通道。** 创建时必须选通道。WorkBuddy 的 Key 发 `auto` / `glm-5.2`；QwenWork 的 Key 发 `auto` 或 `qwork-advanced`；TraeWork 的 Key 发 `auto` 或 `qwen-3.7-plus`。通道和模型对不上会 400 或 403，不会帮你转到另一家。
 3. **某个通道返回 503 `channel_unavailable`：** 这个通道还没导入可用账号。
 4. **QClaw / QwenWork 请在 Windows 上直接跑 `python server.py`。** Linux Docker 读不了这两家用 DPAPI 加密的本机文件；管理页会写明这一点。WorkBuddy 可以继续用 Docker。
 5. 本项目和聊天客户端最好在同一台电脑。客户端如果跑在 Docker 里，Base URL 填 `http://host.docker.internal:8787/v1`，不要填容器自己的 `127.0.0.1`。
@@ -92,19 +93,19 @@ python server.py
 ### 其他启动方式
 
 - **脚本：** Windows 安装 Python 时勾选 Add Python to PATH，在项目目录执行 `.\start.bat`。Linux / macOS：`chmod +x start.sh && ./start.sh`。脚本优先用名为 `buddy2api` 的 Conda 环境，没有 Conda 才建 `.venv`。
-- **Docker：** `powershell -ExecutionPolicy Bypass -File .\start-docker-win.ps1`。本机没有 WorkBuddy 登录目录时脚本仍会启动。容器下拉里仍有三个通道，但 QClaw / QwenWork 请用上面的 `python server.py`。
+- **Docker：** `powershell -ExecutionPolicy Bypass -File .\start-docker-win.ps1`。本机没有 WorkBuddy 登录目录时脚本仍会启动。容器下拉里仍有四个通道，但 QClaw / QwenWork 请用上面的 `python server.py`。TraeWork 登录文件不是 DPAPI，本机 `python server.py` 导入后 Docker 也能用库里的 token。
 
 ### 第一次打开网页之后
 
 本机浏览器一般会自动带上管理 Cookie，不用粘贴 Token。
 
-1. 打开「账号」。下拉里选 WorkBuddy / QClaw / 千问办公，点「重新检测」，再点「一键导入本机登录」。
+1. 打开「账号」。下拉里选 WorkBuddy / QClaw / 千问办公 / TraeWork，点「重新检测」，再点「一键导入本机登录」。
 2. 点该账号的「测试」，能返回一句话就说明这条通道通了。
 3. 打开「API Keys」，**先选同一个通道**再创建。给 Codex 用时 Key 类型选 Codex，接口用 `/v1/responses`。创建后可以再显示、复制完整 Key。
 4. 在客户端里填：
    - Base URL：`http://127.0.0.1:8787/v1`
    - API Key：刚复制的 Key
-   - 模型：WorkBuddy 用 `auto` 即可；QClaw 用 `auto`；千问办公用 `auto` 或 `qwork-advanced`
+   - 模型：WorkBuddy 用 `auto` 即可；QClaw 用 `auto`；千问办公用 `auto` 或 `qwork-advanced`；TraeWork 用 `auto` 或 `qwen-3.7-plus`
 
 管理页打不开或要远程访问时：
 
@@ -149,7 +150,7 @@ python server.py
 |---|---|
 | Base URL | `http://127.0.0.1:8787/v1` |
 | API Key | 管理页创建，已绑定通道 |
-| 模型 | WorkBuddy：`auto` / `glm-5.2`。QClaw：`auto` 或 `qclaw/default`。QwenWork：`auto` 或 `qwork-advanced` |
+| 模型 | WorkBuddy：`auto` / `glm-5.2`。QClaw：`auto` 或 `qclaw/default`。QwenWork：`auto` 或 `qwork-advanced`。TraeWork：`auto` 或 `qwen-3.7-plus` |
 | Stream | 建议开 |
 
 接口：`/v1/chat/completions`、`/v1/responses`、`/v1/models`。没加前缀的 `auto` 走这把 Key 绑定的通道。Codex 用 Responses 接口；管理页选 Codex 类型的 Key 会按 Codex 特征 prompt 做清洗（其它客户端借用这把 Key、但没有 Codex 特征时不改写）。
@@ -185,7 +186,7 @@ curl http://127.0.0.1:8787/v1/chat/completions \
   -d '{"model":"auto","messages":[{"role":"user","content":"你好"}]}'
 ```
 
-QwenWork、QClaw 各用自己那把 Key，不要混用。
+QwenWork、QClaw、TraeWork 各用自己那把 Key，不要混用。
 
 ## 启动参数
 
@@ -200,12 +201,13 @@ QwenWork、QClaw 各用自己那把 Key，不要混用。
 
 | 变量 | 说明 |
 |---|---|
-| `CB_GATEWAY_PROVIDERS` | 启用哪些通道，逗号分隔。默认 `workbuddy,qclaw,qwenwork`。只想留一家时再改 |
+| `CB_GATEWAY_PROVIDERS` | 启用哪些通道，逗号分隔。默认 `workbuddy,qclaw,qwenwork,traework`。只想留一家时再改 |
 | `CB_GATEWAY_AUTO_IMPORT` | 设 `1` 则启动时自动导入。默认 `0` |
 | `CB_GATEWAY_CHECKIN_GAP_MS` | 一键领取间隔，默认 `800` |
 | `CB_AUTH_DIR` | WorkBuddy 登录目录 |
 | `CB_QCLAW_AUTH_DIR` | QClaw 登录目录 |
 | `CB_QWENWORK_AUTH_DIR` | QwenWork 登录目录 |
+| `CB_TRAEWORK_AUTH_DIR` | TraeWork `storage.json` 所在目录 |
 | `CB_HOST_AUTH_DIR` | Docker 脚本用的本机 WorkBuddy 目录 |
 | `CB_GATEWAY_ADMIN_TOKEN` | 固定管理 Token |
 | `CB_GATEWAY_DB_PATH` | 数据库路径 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,15 +2,15 @@
 
 [English](README_EN.md) | [中文](README.md)
 
-> Local consumer AI clients → one OpenAI-compatible API for Codex, OpenCode, Cherry Studio, NextChat, and similar agents. Work Buddy / CodeBuddy, QClaw, and QwenWork are on by default; pick one in the UI dropdown. Each request stays on one channel.
+> Local consumer AI clients → one OpenAI-compatible API for Codex, OpenCode, Cherry Studio, NextChat, and similar agents. Work Buddy / CodeBuddy, QClaw, QwenWork, and TraeWork are on by default; pick one in the UI dropdown. Each request stays on one channel.
 
-Release **2.0.1**. Local use only. Do not expose this on the public internet, and do not share credentials, API keys, or the database.
+Release **2.1.0**. Local use only. Do not expose this on the public internet, and do not share credentials, API keys, or the database.
 
 ## What is this?
 
 Buddy2api listens on `http://127.0.0.1:8787/v1`. You stay signed into the official apps; this gateway imports those sessions and forwards chat. Typical clients use Chat Completions. Codex uses `/v1/responses`; create the key as type Codex in the UI to enable Codex prompt sanitization.
 
-All three channels are on by default. A channel with no local login shows empty on Accounts; nothing is imported until you click Import.
+All four channels are on by default. A channel with no local login shows empty on Accounts; nothing is imported until you click Import.
 
 ```powershell
 python server.py
@@ -21,13 +21,14 @@ python server.py
 | WorkBuddy / CodeBuddy | on | `%LOCALAPPDATA%\CodeBuddyExtension\Data\Public\auth` |
 | QClaw | on | `%APPDATA%\QClaw` |
 | QwenWork | on | `%APPDATA%\QwenWorkCN` |
+| TraeWork | on | `%APPDATA%\TRAE SOLO CN\User\globalStorage` |
 
 Narrow with `CB_GATEWAY_PROVIDERS=workbuddy` if you only want one.
 
 ## Before you start
 
-1. **An empty Accounts page after startup is expected.** 2.0 does not import on boot. Pick a channel → Detect → Import. All three channels are in the dropdown.
-2. **One API key is one channel.** Create the key with a channel selected. A WorkBuddy key uses `auto` / `glm-5.2`; a QwenWork key uses `auto` or `qwork-advanced`. Mismatched model/key returns 400 or 403 — there is no cross-vendor failover.
+1. **An empty Accounts page after startup is expected.** 2.0 does not import on boot. Pick a channel → Detect → Import. All four channels are in the dropdown.
+2. **One API key is one channel.** Create the key with a channel selected. A WorkBuddy key uses `auto` / `glm-5.2`; a QwenWork key uses `auto` or `qwork-advanced`; a TraeWork key uses `auto` or `qwen-3.7-plus`. Mismatched model/key returns 400 or 403 — there is no cross-vendor failover.
 3. **HTTP 503 `channel_unavailable`** means that channel has no imported account.
 4. **Run QClaw / QwenWork with `python server.py` on Windows.** A Linux Docker container cannot decrypt those DPAPI files; the UI says so. WorkBuddy can stay on Docker.
 5. If the chat client is itself in Docker, Base URL is `http://host.docker.internal:8787/v1`.
@@ -88,7 +89,7 @@ curl http://127.0.0.1:8787/v1/chat/completions \
 
 ## Environment
 
-`CB_GATEWAY_PROVIDERS` (default `workbuddy,qclaw,qwenwork`), `CB_GATEWAY_AUTO_IMPORT` (default `0`), `CB_AUTH_DIR` / `CB_QCLAW_AUTH_DIR` / `CB_QWENWORK_AUTH_DIR`, `CB_GATEWAY_ADMIN_TOKEN`, `CB_GATEWAY_MASTER_KEY`.
+`CB_GATEWAY_PROVIDERS` (default `workbuddy,qclaw,qwenwork,traework`), `CB_GATEWAY_AUTO_IMPORT` (default `0`), `CB_AUTH_DIR` / `CB_QCLAW_AUTH_DIR` / `CB_QWENWORK_AUTH_DIR` / `CB_TRAEWORK_AUTH_DIR`, `CB_GATEWAY_ADMIN_TOKEN`, `CB_GATEWAY_MASTER_KEY`.
 
 Keep `--host 127.0.0.1`. Do not share the database, auth folders, or key screenshots.
 

--- a/control_plane.py
+++ b/control_plane.py
@@ -423,11 +423,19 @@ async def checkin_status_all(force: bool = False) -> dict:
         accounts = await _channel_accounts(channel)
         if not accounts:
             continue
-        chunk = await _gather_limited(
-            accounts,
-            lambda account: auth_manager.fetch_checkin_status(account, force=force),
-            limit=2,
-        )
+        fetch_checkin = getattr(provider, "fetch_checkin", None)
+        if fetch_checkin:
+            chunk = await _gather_limited(
+                accounts,
+                lambda account, fn=fetch_checkin: fn(account, force=force),
+                limit=2,
+            )
+        else:
+            chunk = await _gather_limited(
+                accounts,
+                lambda account: auth_manager.fetch_checkin_status(account, force=force),
+                limit=2,
+            )
         for item in chunk:
             if isinstance(item, dict):
                 item["channel"] = channel
@@ -464,8 +472,12 @@ async def checkin_all(channel_filter: list[str] | None = None) -> dict:
             if not first and gap:
                 await asyncio.sleep(gap)
             first = False
-            result = await auth_manager.claim_daily_checkin(account)
-            if result.get("ok"):
+            claim_fn = getattr(provider, "claim_checkin", None)
+            if claim_fn:
+                result = await claim_fn(account)
+            else:
+                result = await auth_manager.claim_daily_checkin(account)
+            if result.get("ok") and not claim_fn:
                 result["resources"] = await auth_manager.fetch_account_resources(account, force=True)
             result["channel"] = channel
             results.append(result)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - CB_GATEWAY_DEFAULT_REASONING_EFFORT=${CB_GATEWAY_DEFAULT_REASONING_EFFORT:-high}
       - CB_GATEWAY_DB_PATH=/app/data/buddy2api.db
       - CB_GATEWAY_AUTO_IMPORT=${CB_GATEWAY_AUTO_IMPORT:-0}
-      - CB_GATEWAY_PROVIDERS=${CB_GATEWAY_PROVIDERS:-workbuddy,qclaw,qwenwork}
+      - CB_GATEWAY_PROVIDERS=${CB_GATEWAY_PROVIDERS:-workbuddy,qclaw,qwenwork,traework}
       - CB_AUTH_DIR=/auth
       - CB_CONTAINER_AUTH_DIR=/auth
       - CB_DOCKER=1

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,0 +1,18 @@
+# Buddy2api v2.1.0
+
+发布日期：2026-08-26
+
+新增 TraeWork 通道。默认打开四家：WorkBuddy、QClaw、千问办公、TraeWork。
+
+## 功能
+
+- 通道 id `traework`。本机登录目录 `%APPDATA%\TRAE SOLO CN\User\globalStorage`（`storage.json`）。可用 `CB_TRAEWORK_AUTH_DIR` 指定。
+- 未设置 `CB_GATEWAY_PROVIDERS` 时，registry 为 `workbuddy,qclaw,qwenwork,traework`。没登录的通道检测为空，不自动入库。
+- TraeWork `auto` 落到 `qwen-3.7-plus`。一把 Key 必须绑通道，不会跨厂切换。
+- TraeWork 支持官方签到与积分余额。对话走 Work session；热门模型可能排队。
+- TraeWork 官方文件不是 Windows DPAPI。Linux Docker 仍默认扫不到该目录；在 Windows 导入进 `./data/buddy2api.db` 后，容器可以继续用库里的 token。QClaw / 千问办公仍然请在本机 `python server.py` 导入。
+
+## 兼容
+
+- 现有 WorkBuddy / QClaw / QwenWork Key 与模型行为不变。
+- 收窄通道：`CB_GATEWAY_PROVIDERS=workbuddy`。

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,4 +1,4 @@
-"""Channel registry. WorkBuddy, QClaw, and QwenWork are enabled by default."""
+"""Channel registry. WorkBuddy, QClaw, QwenWork, and TraeWork are enabled by default."""
 
 from __future__ import annotations
 
@@ -12,14 +12,16 @@ from providers.protocol import (
 )
 from providers.qclaw import PROVIDER as QCLAW_PROVIDER
 from providers.qwenwork import PROVIDER as QWENWORK_PROVIDER
+from providers.traework import PROVIDER as TRAEWORK_PROVIDER
 from providers.workbuddy import PROVIDER as WORKBUDDY_PROVIDER
 
-DEFAULT_PROVIDER_IDS: tuple[str, ...] = ("workbuddy", "qclaw", "qwenwork")
+DEFAULT_PROVIDER_IDS: tuple[str, ...] = ("workbuddy", "qclaw", "qwenwork", "traework")
 
 _LOADED: dict[str, Provider] = {
     "workbuddy": WORKBUDDY_PROVIDER,
     "qclaw": QCLAW_PROVIDER,
     "qwenwork": QWENWORK_PROVIDER,
+    "traework": TRAEWORK_PROVIDER,
 }
 
 

--- a/providers/protocol.py
+++ b/providers/protocol.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal, Protocol, runtime_checkable
 
-ChannelId = Literal["workbuddy", "qclaw", "qwenwork", "qoderwork"]
+ChannelId = Literal["workbuddy", "qclaw", "qwenwork", "qoderwork", "traework"]
 
-KNOWN_CHANNEL_IDS: tuple[ChannelId, ...] = ("workbuddy", "qclaw", "qwenwork", "qoderwork")
+KNOWN_CHANNEL_IDS: tuple[ChannelId, ...] = ("workbuddy", "qclaw", "qwenwork", "qoderwork", "traework")
 KNOWN_CHANNEL_SET = frozenset(KNOWN_CHANNEL_IDS)
 
 

--- a/providers/traework/__init__.py
+++ b/providers/traework/__init__.py
@@ -1,0 +1,94 @@
+"""TraeWork provider. Isolated TraeWork CN adapter."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import auth_manager
+import database as db
+from providers.protocol import ChannelId, QuotaSnapshot
+from providers.traework import chat, quota, store
+from providers.traework.constants import ALIASES, CHANNEL_ID, DISPLAY_NAME, STATIC_MODELS
+from providers.traework.token import TraeWorkAuthError, is_token_expired, refresh_account
+
+
+class TraeWorkProvider:
+    id: ChannelId = CHANNEL_ID
+    display_name = DISPLAY_NAME
+    checkin_supported = True
+
+    def list_models(self) -> list[dict]:
+        return [{"id": item} for item in STATIC_MODELS]
+
+    def alias_map(self) -> dict[str, str]:
+        return dict(ALIASES)
+
+    def accepts_model(self, inner: str) -> bool:
+        return chat.accepts_model(inner)
+
+    def translate_model(self, model: str) -> str:
+        return chat.translate_model(model)
+
+    def pick_account(self, exclude_ids: set[int] | None = None) -> Optional[dict]:
+        return auth_manager.pick_account(exclude_ids, provider=self.id)
+
+    async def pick_account_with_fallback(
+        self, exclude_ids: set[int] | None = None
+    ) -> Optional[dict]:
+        exclude = exclude_ids or set()
+        account = self.pick_account(exclude)
+        if account:
+            if is_token_expired(account):
+                try:
+                    return await refresh_account(account)
+                except TraeWorkAuthError:
+                    pass
+            else:
+                return account
+        expired = [
+            row
+            for row in db.list_accounts(provider=self.id)
+            if row.get("status") == "expired" and row.get("id") not in exclude
+        ]
+        for row in expired:
+            try:
+                return await refresh_account(row)
+            except TraeWorkAuthError:
+                continue
+        return None
+
+    async def has_usable_account(self) -> bool:
+        return await self.pick_account_with_fallback() is not None
+
+    async def chat_completions(self, payload: dict, api_key_info: dict | None) -> tuple:
+        return await chat.chat_completions(payload, api_key_info)
+
+    def parse_credentials(self, body: dict) -> dict:
+        return store.parse_credentials(body)
+
+    def discover(self) -> dict:
+        return store.discover()
+
+    def import_path(self, path: str) -> dict:
+        return store.import_discovered(path)
+
+    def upsert_account(self, parsed: dict) -> dict:
+        return store.upsert_account(parsed)
+
+    async def fetch_quota(self, account: dict) -> QuotaSnapshot:
+        return await quota.fetch_quota(account)
+
+    async def fetch_checkin(self, account: dict, force: bool = False) -> dict:
+        return await quota.fetch_checkin(account, force=force)
+
+    async def claim_checkin(self, account: dict) -> dict:
+        return await quota.claim_checkin(account)
+
+    async def test_chat(self, account: dict, model: str = "qwen-3.7-plus", prompt: str = "ping") -> dict:
+        return await chat.test_chat(account, model, prompt)
+
+    async def refresh(self, account: dict) -> dict:
+        return await refresh_account(account)
+
+
+PROVIDER = TraeWorkProvider()

--- a/providers/traework/chat.py
+++ b/providers/traework/chat.py
@@ -1,0 +1,377 @@
+"""TraeWork chat via remote chat_sessions. Isolated HTTP client."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from typing import AsyncGenerator
+
+import httpx
+
+import auth_manager
+import database as db
+from providers.traework.constants import (
+    AGENT_API,
+    AGENT_ID,
+    ALIASES,
+    CHANNEL_ID,
+    SESSION_MODE,
+    SESSIONS_PATH,
+    STATIC_MODELS,
+)
+from providers.traework.token import TraeWorkAuthError, auth_headers, is_token_expired, refresh_account
+
+
+def translate_model(model: str) -> str:
+    inner = (model or "auto").strip() or "auto"
+    return ALIASES.get(inner, inner)
+
+
+def accepts_model(inner: str) -> bool:
+    value = (inner or "").strip()
+    return value in STATIC_MODELS or value in ALIASES
+
+
+def _last_user_text(payload: dict) -> str:
+    for item in reversed(payload.get("messages") or []):
+        if not isinstance(item, dict) or item.get("role") != "user":
+            continue
+        content = item.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, dict) and part.get("text"):
+                    parts.append(str(part["text"]))
+                elif isinstance(part, str):
+                    parts.append(part)
+            text = "".join(parts).strip()
+            if text:
+                return text
+    return ""
+
+
+def _walk_text(value, bucket: list[str]) -> None:
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("{") or text.startswith("["):
+            try:
+                _walk_text(json.loads(text), bucket)
+            except json.JSONDecodeError:
+                pass
+        return
+    if isinstance(value, dict):
+        kind = str(value.get("type") or "")
+        if kind in {"status", "tool", "tool_call"}:
+            return
+        for key in ("text_content", "text", "markdown", "plain_text", "reasoning_content"):
+            item = value.get(key)
+            if isinstance(item, str) and item.strip():
+                bucket.append(item.strip())
+        content = value.get("content")
+        if isinstance(content, str) and content.strip():
+            if content.startswith("{") or content.startswith("["):
+                _walk_text(content, bucket)
+            elif content.strip() not in bucket:
+                bucket.append(content.strip())
+        elif isinstance(content, (dict, list)):
+            _walk_text(content, bucket)
+        messages = value.get("messages")
+        if isinstance(messages, list):
+            _walk_text(messages, bucket)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _walk_text(item, bucket)
+
+
+def _text_from_event(event: str, payload: dict) -> str:
+    if event in {
+        "heartbeat",
+        "status_changed",
+        "platform_timing",
+        "timing_events",
+        "token_usage",
+        "model_config",
+        "project_name_message",
+        "session_title_message",
+        "session_icon_message",
+        "metadata",
+    }:
+        return ""
+    bucket: list[str] = []
+    _walk_text(payload, bucket)
+    return "\n".join(dict.fromkeys(bucket)).strip()
+
+
+def extract_assistant_text(items: list) -> str:
+    chunks: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("role") not in {"assistant", "system"} and item.get("message_type") != "task":
+            continue
+        _walk_text(item.get("content"), chunks)
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for chunk in chunks:
+        if chunk not in seen:
+            seen.add(chunk)
+            ordered.append(chunk)
+    return "\n".join(ordered).strip()
+
+
+def _openai_json(model: str, text: str, finish: str = "stop") -> dict:
+    return {
+        "id": f"traework-{uuid.uuid4().hex[:12]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": finish,
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
+async def _pick(tried: set[int]) -> dict | None:
+    account = auth_manager.pick_account(tried, provider=CHANNEL_ID)
+    if account:
+        if is_token_expired(account):
+            try:
+                return await refresh_account(account)
+            except TraeWorkAuthError:
+                pass
+        else:
+            return account
+    expired = [
+        row
+        for row in db.list_accounts(provider=CHANNEL_ID)
+        if row.get("status") == "expired" and row.get("id") not in tried
+    ]
+    for row in expired:
+        try:
+            return await refresh_account(row)
+        except TraeWorkAuthError:
+            continue
+    return None
+
+
+def _log(api_key_info, account, model_name, stream, finish, status, error, t0):
+    try:
+        db.record_request(
+            {
+                "api_key_id": api_key_info["id"] if api_key_info else None,
+                "api_key_name": api_key_info["name"] if api_key_info else None,
+                "account_id": account["id"] if account else None,
+                "account_name": account.get("name") if account else None,
+                "provider": CHANNEL_ID,
+                "model": model_name,
+                "stream": 1 if stream else 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "credit": 0,
+                "finish_reason": finish,
+                "duration_ms": int((time.time() - t0) * 1000),
+                "status_code": status,
+                "error_msg": error,
+                "increment_usage": True,
+            }
+        )
+    except Exception:
+        pass
+
+
+async def _turn(account: dict, prompt: str, model: str, timeout: float = 90.0) -> str:
+    headers = auth_headers(account)
+    session_url = f"{AGENT_API}{SESSIONS_PATH}"
+    sid = ""
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        created = await client.post(
+            session_url,
+            headers=headers,
+            json={"mode": SESSION_MODE, "auto_create_project": True, "origin": "web"},
+        )
+        if created.status_code >= 400:
+            raise TraeWorkAuthError(f"create session HTTP {created.status_code}")
+        data = created.json() if created.content else {}
+        if data.get("code") not in (None, 0):
+            raise TraeWorkAuthError(str(data.get("message") or data.get("code")))
+        sid = str((data.get("data") or {}).get("chat_session_id") or "")
+        if not sid:
+            raise TraeWorkAuthError("create session missing chat_session_id")
+        pieces: list[str] = []
+        finished = asyncio.Event()
+
+        async def read_events() -> None:
+            event_name = "message"
+            try:
+                async with client.stream(
+                    "GET",
+                    f"{session_url}/{sid}/events",
+                    headers={**headers, "Accept": "text/event-stream"},
+                ) as response:
+                    if response.status_code >= 400:
+                        finished.set()
+                        return
+                    async for line in response.aiter_lines():
+                        if line.startswith("event:"):
+                            event_name = line[6:].strip() or "message"
+                            continue
+                        if not line.startswith("data:"):
+                            continue
+                        raw = line[5:].strip()
+                        try:
+                            event_payload = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        text = _text_from_event(event_name, event_payload if isinstance(event_payload, dict) else {})
+                        if text:
+                            pieces.append(text)
+                        if event_name == "done":
+                            finished.set()
+                            return
+            except httpx.HTTPError:
+                finished.set()
+
+        task = asyncio.create_task(read_events())
+        try:
+            await asyncio.sleep(0.35)
+            query = json.dumps(
+                [{"type": "text", "data": {"content": prompt}}],
+                ensure_ascii=False,
+            )
+            sent = await client.post(
+                f"{session_url}/{sid}/messages",
+                headers=headers,
+                json={
+                    "chat_session_id": sid,
+                    "content": [],
+                    "query": query,
+                    "model_name": model,
+                    "agent_id": AGENT_ID,
+                    "agent_type": AGENT_ID,
+                },
+            )
+            payload = sent.json() if sent.content else {}
+            if sent.status_code >= 400 or payload.get("code") not in (None, 0):
+                raise TraeWorkAuthError(str(payload.get("message") or f"HTTP {sent.status_code}"))
+            try:
+                await asyncio.wait_for(finished.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                pass
+            messages = await client.get(f"{session_url}/{sid}/messages", headers=headers)
+            body = messages.json() if messages.content else {}
+            items = ((body.get("data") or {}).get("items") or [])
+            text = extract_assistant_text(items) or "\n".join(dict.fromkeys(pieces)).strip()
+            if not text:
+                raise TraeWorkAuthError("TraeWork turn finished without assistant text")
+            return text
+        finally:
+            task.cancel()
+            try:
+                await client.delete(f"{session_url}/{sid}", headers=headers)
+            except Exception:
+                pass
+
+
+async def chat_completions(payload: dict, api_key_info: dict | None) -> tuple:
+    model = translate_model(str(payload.get("model") or "auto"))
+    prompt = _last_user_text(payload)
+    if not prompt:
+        return (
+            "error",
+            (400, {"error": {"message": "messages must include a user turn", "type": "invalid_request_error"}}),
+        )
+    stream = bool(payload.get("stream"))
+    tried: set[int] = set()
+    last_error = None
+    for _ in range(3):
+        account = await _pick(tried)
+        if not account:
+            break
+        tried.add(int(account["id"]))
+        t0 = time.time()
+        try:
+            text = await _turn(account, prompt, model)
+            auth_manager.mark_account_success(account["id"])
+            _log(api_key_info, account, payload.get("model") or model, stream, "stop", 200, "", t0)
+            if stream:
+                return ("stream", _stream_once(text, str(payload.get("model") or model)))
+            return ("json", _openai_json(str(payload.get("model") or model), text))
+        except TraeWorkAuthError as exc:
+            auth_manager.mark_account_failure(account["id"], 503)
+            last_error = ("error", (503, {"error": {"message": str(exc)[:240], "type": "server_error"}}))
+            _log(api_key_info, account, payload.get("model") or model, stream, "error", 503, str(exc)[:240], t0)
+            continue
+        except httpx.HTTPError as exc:
+            auth_manager.mark_account_failure(account["id"], 503)
+            last_error = ("error", (503, {"error": {"message": str(exc)[:240], "type": "server_error"}}))
+            continue
+    return last_error or (
+        "error",
+        (
+            503,
+            {
+                "error": {
+                    "message": "No available accounts",
+                    "type": "channel_unavailable",
+                    "code": "channel_unavailable",
+                }
+            },
+        ),
+    )
+
+
+async def _stream_once(text: str, model: str) -> AsyncGenerator[str, None]:
+    chunk = {
+        "id": f"traework-{uuid.uuid4().hex[:12]}",
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": 0, "delta": {"role": "assistant", "content": text}, "finish_reason": None}],
+    }
+    yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+    done = {
+        "id": chunk["id"],
+        "object": "chat.completion.chunk",
+        "created": chunk["created"],
+        "model": model,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    }
+    yield f"data: {json.dumps(done, ensure_ascii=False)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+async def test_chat(account: dict, model: str = "qwen-3.7-plus", prompt: str = "请回复：pong") -> dict:
+    t0 = time.time()
+    try:
+        text = await _turn(account, prompt or "请回复：pong", translate_model(model or "auto"), timeout=90.0)
+    except TraeWorkAuthError as exc:
+        return {
+            "ok": False,
+            "status_code": 503,
+            "duration_ms": int((time.time() - t0) * 1000),
+            "message": str(exc)[:400],
+        }
+    except httpx.HTTPError as exc:
+        return {
+            "ok": False,
+            "status_code": 0,
+            "duration_ms": int((time.time() - t0) * 1000),
+            "message": str(exc)[:400],
+        }
+    return {
+        "ok": True,
+        "status_code": 200,
+        "duration_ms": int((time.time() - t0) * 1000),
+        "message": text[:400],
+    }

--- a/providers/traework/constants.py
+++ b/providers/traework/constants.py
@@ -1,0 +1,52 @@
+"""TraeWork CN (TRAE SOLO CN) protocol constants.
+
+Hosts, client id, and app version were read from the official
+0.1.56 product.json and live requests on this machine.
+"""
+
+from __future__ import annotations
+
+CHANNEL_ID = "traework"
+DISPLAY_NAME = "TraeWork"
+
+IDE_VERSION = "0.1.56"
+CLIENT_ID = "en1oxy7wnw8j9n"
+PLATFORM_CODE = "SOLO_PC"
+PRODUCT_CODE = "SOLO_Lite"
+REQ_SOURCE = 2
+APP_ID = "6eefa01c-1036-4c7e-9ca5-d891f63bfcd8"
+
+UG_API = "https://api.trae.cn"
+AGENT_API = "https://trae-api-cn.mchost.guru"
+
+CHECKIN_STATUS_PATH = "/trae/api/v2/ug/checkin_credits/status"
+CHECKIN_CLAIM_PATH = "/trae/api/v2/ug/checkin_credits/claim"
+USAGE_PATH = "/trae/api/v2/pay/ide_user_ent_usage"
+EXCHANGE_PATH = "/trae/api/v3/oauth/ExchangeToken"
+GET_USER_PATH = "/cloudide/api/v3/trae/GetUserInfo"
+MODELS_PATH = "/api/remote/v1/models"
+SESSIONS_PATH = "/api/remote/v1/chat_sessions"
+
+AUTH_STORAGE_KEY = "iCubeAuthInfo://icube.cloudide"
+AUTH_DEVICE_PREFIX = "iCubeAuthInfo://icube-dc:"
+STORAGE_FILENAME = "storage.json"
+
+AGENT_ID = "solo_work_lite"
+SESSION_MODE = "work"
+
+STATIC_MODELS = (
+    "qwen-3.7-plus",
+    "Doubao-Seed-2.1-Turbo",
+    "DeepSeek-V4-Flash-Official",
+    "qwen-3.5",
+    "glm-5",
+    "glm-5.1",
+    "kimi-k2.5",
+    "Doubao-Seed-2.0-Code",
+)
+
+ALIASES = {
+    "auto": "qwen-3.7-plus",
+}
+
+USER_AGENT = "TRAE-SOLO-CN/0.1.56"

--- a/providers/traework/crypto.py
+++ b/providers/traework/crypto.py
@@ -1,0 +1,71 @@
+"""Decrypt TraeWork storage.json iCubeAuthInfo blobs.
+
+Algorithm matches official TRAE SOLO CN 0.1.56 `byteCrypto.js`:
+magic `tc\\x05\\x10\\x00\\x00`, AES-128-CBC, SHA-512 checksum.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.padding import PKCS7
+
+from credential_crypto import CredentialCryptoError
+
+_MAGIC = b"tc\x05\x10\x00\x00"
+_HEADER = 6
+_KEY_LEN = 32
+_HASH_LEN = 64
+
+# Official client XOR tables (ure ^ dre) used as SHA-512 salt.
+_URE = bytes(
+    [
+        82, 9, 106, 213, 48, 54, 165, 56, 191, 64, 163, 158, 129, 243, 215, 251,
+        124, 227, 57, 130, 155, 47, 255, 135, 52, 142, 67, 68, 196, 222, 233, 203,
+        84, 123, 148, 50, 166, 194, 35, 61, 238, 76, 149, 11, 66, 250, 195, 78,
+        8, 46, 161, 102, 40, 217, 36, 178, 118, 91, 162, 73, 109, 139, 209, 37,
+    ]
+)
+_DRE = bytes(
+    [
+        31, 221, 168, 51, 136, 7, 199, 49, 177, 18, 16, 89, 39, 128, 236, 95,
+        96, 81, 127, 169, 25, 181, 74, 13, 45, 229, 122, 159, 147, 201, 156, 239,
+        160, 224, 59, 77, 174, 42, 245, 176, 200, 235, 187, 60, 131, 83, 153, 97,
+        23, 43, 4, 126, 186, 119, 214, 38, 225, 105, 20, 99, 85, 33, 12, 125,
+    ]
+)
+_SALT = bytes(a ^ b for a, b in zip(_URE, _DRE))
+
+
+def decrypt_tc_b64(value: str) -> str:
+    if not value or not isinstance(value, str):
+        raise CredentialCryptoError("TraeWork auth blob is empty")
+    try:
+        blob = base64.b64decode(value)
+    except Exception as exc:
+        raise CredentialCryptoError("TraeWork auth blob is not base64") from exc
+    if not blob.startswith(_MAGIC):
+        raise CredentialCryptoError("TraeWork auth blob is not tc AES")
+    key_mat = blob[_HEADER : _HEADER + _KEY_LEN]
+    cipher = blob[_HEADER + _KEY_LEN :]
+    if len(key_mat) != _KEY_LEN or not cipher or len(cipher) % 16:
+        raise CredentialCryptoError("TraeWork auth blob is truncated")
+    mixed = hashlib.sha512(key_mat).digest() + _SALT
+    derived = hashlib.sha512(mixed).digest()
+    aes_key, iv = derived[:16], derived[16:32]
+    decryptor = Cipher(algorithms.AES(aes_key), modes.CBC(iv)).decryptor()
+    padded = decryptor.update(cipher) + decryptor.finalize()
+    unpadder = PKCS7(128).unpadder()
+    try:
+        plain = unpadder.update(padded) + unpadder.finalize()
+    except ValueError as exc:
+        raise CredentialCryptoError("TraeWork auth blob padding is invalid") from exc
+    checksum, body = plain[:_HASH_LEN], plain[_HASH_LEN:]
+    if hashlib.sha512(body).digest() != checksum:
+        raise CredentialCryptoError("TraeWork auth blob checksum failed")
+    try:
+        return body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CredentialCryptoError("TraeWork auth blob is not UTF-8") from exc

--- a/providers/traework/quota.py
+++ b/providers/traework/quota.py
@@ -1,0 +1,164 @@
+"""TraeWork check-in and official credit usage."""
+
+from __future__ import annotations
+
+import httpx
+
+from providers.protocol import QuotaSnapshot
+from providers.traework.constants import (
+    CHANNEL_ID,
+    CHECKIN_CLAIM_PATH,
+    CHECKIN_STATUS_PATH,
+    REQ_SOURCE,
+    UG_API,
+    USAGE_PATH,
+)
+from providers.traework.token import auth_headers, extra_of
+
+
+def _host(account: dict) -> str:
+    extra = extra_of(account)
+    return str(extra.get("host") or UG_API).rstrip("/") or UG_API
+
+
+def _checkin_row(
+    account: dict,
+    *,
+    ok: bool,
+    status_code: int = 0,
+    message: str = "",
+    claimed: bool = False,
+    already_claimed: bool = False,
+    credit: float = 0,
+    today_checked_in: bool | None = None,
+    extra: dict | None = None,
+) -> dict:
+    return {
+        "account_id": account.get("id"),
+        "account_name": account.get("nickname") or account.get("name") or str(account.get("id")),
+        "ok": ok,
+        "claimed": claimed,
+        "already_claimed": already_claimed,
+        "status_code": status_code,
+        "message": message,
+        "credit": credit,
+        "active": True,
+        "today_checked_in": already_claimed if today_checked_in is None else today_checked_in,
+        "today_credit": credit,
+        "channel": CHANNEL_ID,
+        **(extra or {}),
+    }
+
+
+async def fetch_checkin(account: dict, force: bool = False) -> dict:
+    url = f"{_host(account)}{CHECKIN_STATUS_PATH}"
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.post(url, headers=auth_headers(account), json={})
+    except httpx.HTTPError as exc:
+        return _checkin_row(account, ok=False, message=str(exc)[:240])
+    try:
+        data = response.json()
+    except ValueError:
+        data = {}
+    if response.status_code >= 400 or (isinstance(data, dict) and data.get("code") not in (None, 0)):
+        return _checkin_row(
+            account,
+            ok=False,
+            status_code=response.status_code,
+            message=str((data or {}).get("message") or f"HTTP {response.status_code}")[:240],
+        )
+    checked = bool(data.get("checked_in") or data.get("checkedIn"))
+    credit = float(data.get("credits") or data.get("credit") or 0)
+    return _checkin_row(
+        account,
+        ok=True,
+        status_code=response.status_code,
+        already_claimed=checked,
+        today_checked_in=checked,
+        credit=credit,
+        message=str(data.get("message") or "success"),
+        extra={"enable": bool(data.get("enable", True))},
+    )
+
+
+async def claim_checkin(account: dict) -> dict:
+    status = await fetch_checkin(account, force=True)
+    if not status.get("ok"):
+        return status
+    if status.get("already_claimed") or status.get("today_checked_in"):
+        status["already_claimed"] = True
+        status["message"] = "今日已领取"
+        return status
+    url = f"{_host(account)}{CHECKIN_CLAIM_PATH}"
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, headers=auth_headers(account), json={})
+    except httpx.HTTPError as exc:
+        return _checkin_row(account, ok=False, message=str(exc)[:240])
+    try:
+        data = response.json()
+    except ValueError:
+        data = {}
+    if response.status_code >= 400 or (isinstance(data, dict) and data.get("code") not in (None, 0)):
+        return _checkin_row(
+            account,
+            ok=False,
+            status_code=response.status_code,
+            message=str((data or {}).get("message") or f"HTTP {response.status_code}")[:240],
+        )
+    credit = float(data.get("credits") or data.get("credit") or status.get("credit") or 0)
+    return _checkin_row(
+        account,
+        ok=True,
+        status_code=response.status_code,
+        claimed=True,
+        credit=credit,
+        message=str(data.get("message") or "success"),
+    )
+
+
+async def fetch_quota(account: dict) -> QuotaSnapshot:
+    url = f"{_host(account)}{USAGE_PATH}"
+    body = {"require_usage": True, "req_source": REQ_SOURCE}
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, headers=auth_headers(account), json=body)
+    except httpx.HTTPError as exc:
+        return QuotaSnapshot(
+            ok=False,
+            channel=CHANNEL_ID,
+            account_id=int(account.get("id") or 0),
+            unit="credit",
+            remaining=None,
+            message=str(exc)[:240],
+        )
+    if response.status_code >= 400:
+        return QuotaSnapshot(
+            ok=False,
+            channel=CHANNEL_ID,
+            account_id=int(account.get("id") or 0),
+            unit="credit",
+            remaining=None,
+            message=f"HTTP {response.status_code}",
+        )
+    try:
+        data = response.json()
+    except ValueError:
+        data = {}
+    usage = data.get("usage_summary") if isinstance(data.get("usage_summary"), dict) else {}
+    total = usage.get("total_amount")
+    consumed = usage.get("consumed_amount")
+    remaining = None
+    if isinstance(total, (int, float)):
+        remaining = float(total) - float(consumed or 0)
+    return QuotaSnapshot(
+        ok=True,
+        channel=CHANNEL_ID,
+        account_id=int(account.get("id") or 0),
+        unit="credit",
+        remaining=remaining,
+        extra={"consumed": consumed, "total": total},
+        unsupported=remaining is None,
+        message="" if remaining is not None else "quota unit unknown",
+    )

--- a/providers/traework/store.py
+++ b/providers/traework/store.py
@@ -1,0 +1,288 @@
+"""Read official TraeWork storage.json. Never scans WorkBuddy CB_AUTH_DIR."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from credential_crypto import CredentialCryptoError
+from providers.traework.constants import (
+    AUTH_DEVICE_PREFIX,
+    AUTH_STORAGE_KEY,
+    CHANNEL_ID,
+    IDE_VERSION,
+    STORAGE_FILENAME,
+    UG_API,
+)
+from providers.traework.crypto import decrypt_tc_b64
+
+
+def traework_user_data_dir() -> Path:
+    override = os.environ.get("CB_TRAEWORK_USER_DATA_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+    return Path(appdata) / "TRAE SOLO CN"
+
+
+def traework_auth_dirs() -> list[Path]:
+    dirs: list[Path] = []
+    explicit = os.environ.get("CB_TRAEWORK_AUTH_DIR", "").strip()
+    if explicit:
+        dirs.append(Path(explicit).expanduser())
+    dirs.append(traework_user_data_dir() / "User" / "globalStorage")
+    seen: set[str] = set()
+    out: list[Path] = []
+    for item in dirs:
+        key = str(item)
+        if key not in seen:
+            seen.add(key)
+            out.append(item)
+    return out
+
+
+def iso_to_ms(value) -> int:
+    if value in (None, ""):
+        return 0
+    if isinstance(value, (int, float)):
+        number = int(value)
+        return number if number > 10_000_000_000 else number * 1000
+    text = str(value).strip()
+    if not text:
+        return 0
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return 0
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp() * 1000)
+
+
+def _jwt_exp_ms(token: str) -> int:
+    try:
+        import base64
+
+        parts = token.split(".")
+        if len(parts) < 2:
+            return 0
+        payload = parts[1] + "=" * (-len(parts[1]) % 4)
+        data = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+        return iso_to_ms(data.get("exp"))
+    except Exception:
+        return 0
+
+
+def _read_storage(path: Path) -> dict:
+    raw = path.read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise CredentialCryptoError("TraeWork storage.json is not an object")
+    return payload
+
+
+def _device_keys(storage: dict) -> tuple[str, str, str, str]:
+    public_pem = ""
+    private_pem = ""
+    device_id = ""
+    for key, value in storage.items():
+        if not str(key).startswith(AUTH_DEVICE_PREFIX):
+            continue
+        device_id = str(key)[len(AUTH_DEVICE_PREFIX) :]
+        if not isinstance(value, str):
+            continue
+        try:
+            blob = json.loads(decrypt_tc_b64(value))
+        except Exception:
+            continue
+        if isinstance(blob, dict):
+            public_pem = str(blob.get("publicKeyPEM") or "")
+            private_pem = str(blob.get("privateKeyPEM") or "")
+            break
+    machine = str(storage.get("telemetry.machineId") or "")
+    return device_id, public_pem, private_pem, machine
+
+
+def session_to_account(document: dict, storage: dict | None = None, source: str = "") -> dict:
+    account = document.get("account") if isinstance(document.get("account"), dict) else {}
+    uid = str(document.get("userId") or account.get("userId") or "")
+    name = str(account.get("username") or document.get("username") or "")
+    access = str(document.get("token") or document.get("access_token") or "")
+    refresh = str(document.get("refreshToken") or document.get("refresh_token") or "")
+    host = str(document.get("host") or UG_API)
+    device_id = public_pem = private_pem = machine_id = ""
+    if storage:
+        device_id, public_pem, private_pem, machine_id = _device_keys(storage)
+    extra = {
+        "host": host,
+        "device_id": device_id,
+        "machine_id": machine_id,
+        "public_key_pem": public_pem,
+        "private_key_pem": private_pem,
+        "user_tag": str(account.get("userTag") or ""),
+        "store_region": str(account.get("storeRegion") or ""),
+        "source": source or "import",
+        "client_version": IDE_VERSION,
+    }
+    return {
+        "name": name or f"traework-{(uid or 'user')[:8]}",
+        "uid": uid,
+        "nickname": name,
+        "access_token": access,
+        "refresh_token": refresh,
+        "expires_at": iso_to_ms(document.get("expiredAt")) or _jwt_exp_ms(access),
+        "refresh_expires_at": iso_to_ms(document.get("refreshExpiredAt")),
+        "provider": CHANNEL_ID,
+        "domain": host.replace("https://", "").replace("http://", ""),
+        "extra": extra,
+        "status": "active",
+    }
+
+
+def parse_credentials(body: dict) -> dict:
+    if not isinstance(body, dict):
+        raise ValueError("TraeWork credentials must be a JSON object")
+    nested = body.get("account") if isinstance(body.get("account"), dict) else {}
+    document = {
+        "token": body.get("token") or body.get("access_token") or "",
+        "refreshToken": body.get("refreshToken") or body.get("refresh_token") or "",
+        "expiredAt": body.get("expiredAt") or body.get("expires_at"),
+        "refreshExpiredAt": body.get("refreshExpiredAt") or body.get("refresh_expires_at"),
+        "userId": body.get("userId") or body.get("uid") or nested.get("userId") or "",
+        "host": body.get("host") or UG_API,
+        "account": {
+            "username": nested.get("username") or body.get("nickname") or body.get("name") or "",
+            "userTag": nested.get("userTag") or "",
+            "storeRegion": nested.get("storeRegion") or "",
+        },
+    }
+    parsed = session_to_account(document, source="paste")
+    extra = parsed.get("extra") if isinstance(parsed.get("extra"), dict) else {}
+    extra["device_id"] = str(body.get("device_id") or extra.get("device_id") or "")
+    extra["machine_id"] = str(body.get("machine_id") or extra.get("machine_id") or "")
+    extra["public_key_pem"] = str(body.get("public_key_pem") or extra.get("public_key_pem") or "")
+    extra["private_key_pem"] = str(body.get("private_key_pem") or extra.get("private_key_pem") or "")
+    parsed["extra"] = extra
+    if not parsed["access_token"] and not parsed["refresh_token"]:
+        raise ValueError("TraeWork credentials need token / refreshToken")
+    return parsed
+
+
+def import_discovered(path: str) -> dict:
+    target = Path(path)
+    allowed = [folder.resolve() for folder in traework_auth_dirs() if folder.exists()]
+    resolved = target.resolve()
+    if allowed and not any(_is_relative_to(resolved, root) for root in allowed):
+        raise ValueError("path is outside CB_TRAEWORK_AUTH_DIR / official TraeWork data dir")
+    if target.suffix.lower() == ".json" and target.name != STORAGE_FILENAME:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+        return parse_credentials(payload if isinstance(payload, dict) else {})
+    storage = _read_storage(target)
+    blob = storage.get(AUTH_STORAGE_KEY)
+    if not isinstance(blob, str) or not blob:
+        raise ValueError("TraeWork storage.json has no iCubeAuthInfo")
+    document = json.loads(decrypt_tc_b64(blob))
+    if not isinstance(document, dict):
+        raise ValueError("TraeWork auth JSON is not an object")
+    parsed = session_to_account(document, storage=storage, source=str(resolved))
+    extra = parsed.get("extra") if isinstance(parsed.get("extra"), dict) else {}
+    extra["auth_path"] = str(resolved)
+    parsed["extra"] = extra
+    if not parsed.get("access_token") and not parsed.get("refresh_token"):
+        raise ValueError("failed to decrypt official TraeWork storage.json")
+    return parsed
+
+
+def discover() -> dict:
+    import database as db
+
+    dirs_info = []
+    files: list[dict] = []
+    existing = {
+        str(row.get("uid"))
+        for row in db.list_accounts(provider=CHANNEL_ID)
+        if row.get("uid")
+    }
+    for folder in traework_auth_dirs():
+        exists = folder.is_dir()
+        dirs_info.append({"path": str(folder), "exists": exists, "file_count": 0})
+        if not exists:
+            continue
+        count = 0
+        path = folder / STORAGE_FILENAME
+        if path.is_file():
+            count += 1
+            files.append(_file_meta(path, existing))
+        dirs_info[-1]["file_count"] = count
+    return {
+        "dirs": dirs_info,
+        "files": files,
+        "file_count": len(files),
+        "valid_count": sum(1 for item in files if item.get("valid")),
+        "importable_count": sum(
+            1 for item in files if item.get("valid") and not item.get("already_imported")
+        ),
+        "channel": CHANNEL_ID,
+    }
+
+
+def _file_meta(path: Path, existing_uids: set[str]) -> dict:
+    reason = ""
+    valid = False
+    uid = ""
+    name = path.name
+    try:
+        parsed = import_discovered(str(path))
+        valid = bool(parsed.get("access_token") or parsed.get("refresh_token"))
+        uid = str(parsed.get("uid") or "")
+        name = parsed.get("nickname") or name
+        if not valid:
+            reason = "missing token"
+    except Exception as exc:
+        reason = str(exc)[:160]
+        valid = False
+    masked = (uid[:6] + "…") if len(uid) > 6 else uid
+    return {
+        "channel": CHANNEL_ID,
+        "path": str(path),
+        "valid": valid,
+        "reason": reason,
+        "account_name": name,
+        "uid_masked": masked,
+        "already_imported": bool(uid and uid in existing_uids),
+    }
+
+
+def upsert_account(parsed: dict) -> dict:
+    import database as db
+
+    uid = str(parsed.get("uid") or "")
+    if uid:
+        for row in db.list_accounts(provider=CHANNEL_ID):
+            if str(row.get("uid") or "") == uid:
+                patch = {
+                    "access_token": parsed.get("access_token") or "",
+                    "refresh_token": parsed.get("refresh_token") or "",
+                    "expires_at": parsed.get("expires_at") or 0,
+                    "refresh_expires_at": parsed.get("refresh_expires_at") or 0,
+                    "nickname": parsed.get("nickname") or row.get("nickname") or "",
+                    "name": parsed.get("name") or row.get("name") or "",
+                    "extra": parsed.get("extra") or row.get("extra") or {},
+                    "status": "active",
+                }
+                db.update_account(row["id"], patch)
+                return {"id": row["id"], "updated": True}
+    aid = db.add_account(parsed)
+    return {"id": aid, "updated": False}
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False

--- a/providers/traework/token.py
+++ b/providers/traework/token.py
@@ -1,0 +1,144 @@
+"""TraeWork token refresh via ExchangeToken. Isolated from WorkBuddy."""
+
+from __future__ import annotations
+
+import os
+import time
+import httpx
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from providers.traework.constants import (
+    CLIENT_ID,
+    EXCHANGE_PATH,
+    IDE_VERSION,
+    PLATFORM_CODE,
+    UG_API,
+)
+from providers.traework.store import iso_to_ms
+
+
+class TraeWorkAuthError(RuntimeError):
+    pass
+
+
+def is_token_expired(account: dict, skew_ms: int = 300_000) -> bool:
+    expires_at = int(account.get("expires_at") or 0)
+    if expires_at <= 0:
+        return False
+    return time.time() * 1000 >= expires_at - skew_ms
+
+
+def extra_of(account: dict) -> dict:
+    extra = account.get("extra") if isinstance(account.get("extra"), dict) else {}
+    return extra
+
+
+def auth_headers(account: dict) -> dict[str, str]:
+    extra = extra_of(account)
+    token = str(account.get("access_token") or "")
+    device_id = str(extra.get("device_id") or "")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Cloud-IDE-JWT {token}",
+        "User-Agent": f"TRAE-SOLO-CN/{IDE_VERSION}",
+    }
+    if device_id:
+        headers["x-device-id"] = device_id
+    return headers
+
+
+def oauth_headers(token: str) -> dict[str, str]:
+    return {"Content-Type": "application/json", "x-cloudide-token": token}
+
+
+def _host(account: dict) -> str:
+    extra = extra_of(account)
+    host = str(extra.get("host") or UG_API).rstrip("/")
+    return host or UG_API
+
+
+def _device_info(account: dict) -> dict:
+    extra = extra_of(account)
+    return {
+        "DeviceID": str(extra.get("device_id") or ""),
+        "MachineID": str(extra.get("machine_id") or ""),
+        "PlatformCode": PLATFORM_CODE,
+        "DeviceType": "PC",
+        "DeviceName": os.environ.get("COMPUTERNAME") or os.environ.get("USERNAME") or "PC",
+        "ClientVersion": IDE_VERSION,
+        "DevicePublicKey": str(extra.get("public_key_pem") or ""),
+        "OSInfo": "windows",
+    }
+
+
+def _device_proof(refresh_token: str, private_pem: str) -> dict:
+    timestamp = int(time.time())
+    nonce = os.urandom(16).hex()
+    material = "\n".join(
+        ["POST", EXCHANGE_PATH, CLIENT_ID, refresh_token, str(timestamp), nonce]
+    )
+    key = serialization.load_pem_private_key(private_pem.encode("utf-8"), password=None)
+    if not isinstance(key, ec.EllipticCurvePrivateKey):
+        raise TraeWorkAuthError("TraeWork device key is not ECDSA")
+    der = key.sign(material.encode("utf-8"), ec.ECDSA(hashes.SHA256()))
+    import base64
+
+    signature = base64.b64encode(der).decode("ascii")
+    return {"Signature": signature, "Timestamp": timestamp, "Nonce": nonce}
+
+
+def _parse_exchange(result: dict) -> dict:
+    token = str(result.get("Token") or result.get("token") or "")
+    refresh = str(result.get("RefreshToken") or result.get("refreshToken") or "")
+    expired_at = iso_to_ms(result.get("TokenExpireAt") or result.get("expiredAt"))
+    if not expired_at and result.get("TokenExpireDuration"):
+        expired_at = int(time.time() * 1000) + int(result["TokenExpireDuration"])
+    refresh_expired = iso_to_ms(result.get("RefreshExpireAt") or result.get("refreshExpiredAt"))
+    return {
+        "access_token": token,
+        "refresh_token": refresh,
+        "expires_at": expired_at,
+        "refresh_expires_at": refresh_expired,
+    }
+
+
+async def refresh_account(account: dict) -> dict:
+    import database as db
+
+    refresh = str(account.get("refresh_token") or "")
+    extra = extra_of(account)
+    private_pem = str(extra.get("private_key_pem") or "")
+    if not refresh:
+        raise TraeWorkAuthError("TraeWork account has no refresh_token")
+    if not private_pem:
+        raise TraeWorkAuthError("TraeWork account has no device private key")
+    access = str(account.get("access_token") or "")
+    proof = _device_proof(refresh, private_pem)
+    body = {
+        "ClientID": CLIENT_ID,
+        "ClientSecret": "",
+        "RefreshToken": refresh,
+        "DeviceInfo": _device_info(account),
+        "DeviceProof": proof,
+        "IDEVersion": IDE_VERSION,
+    }
+    url = f"{_host(account)}{EXCHANGE_PATH}"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(url, headers=oauth_headers(access), json=body)
+    if response.status_code >= 400:
+        raise TraeWorkAuthError(f"ExchangeToken failed: HTTP {response.status_code}")
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise TraeWorkAuthError("ExchangeToken returned non-JSON") from exc
+    result = data.get("Result") if isinstance(data.get("Result"), dict) else data
+    parsed = _parse_exchange(result if isinstance(result, dict) else {})
+    if not parsed.get("access_token"):
+        raise TraeWorkAuthError("ExchangeToken response missing Token")
+    patch = {**parsed, "status": "active"}
+    if not patch.get("refresh_token"):
+        patch["refresh_token"] = refresh
+    db.update_account(int(account["id"]), patch)
+    fresh = db.get_account(account["id"])
+    return fresh or {**account, **patch}

--- a/server.py
+++ b/server.py
@@ -712,7 +712,8 @@ async def admin_test_account(
         test = getattr(provider, "test_chat", None)
         if test is None:
             raise HTTPException(status_code=400, detail=f"Channel '{channel}' does not support account test")
-        return await test(account, model or "auto", prompt or "ping")
+        default_prompt = "请回复：pong" if channel == "traework" else "ping"
+        return await test(account, model or "auto", prompt or default_prompt)
     return await proxy.test_account_chat(account, model or "auto", prompt or "ping")
 
 

--- a/tests/test_provider_schema.py
+++ b/tests/test_provider_schema.py
@@ -22,7 +22,7 @@ def test_default_registry_enables_wave1_channels(monkeypatch):
     import providers
 
     monkeypatch.delenv("CB_GATEWAY_PROVIDERS", raising=False)
-    assert providers.enabled_provider_ids() == ["workbuddy", "qclaw", "qwenwork"]
+    assert providers.enabled_provider_ids() == ["workbuddy", "qclaw", "qwenwork", "traework"]
     monkeypatch.setenv("CB_GATEWAY_PROVIDERS", "workbuddy")
     assert providers.enabled_provider_ids() == ["workbuddy"]
     assert providers.get_provider("qclaw") is None

--- a/tests/test_qclaw.py
+++ b/tests/test_qclaw.py
@@ -42,7 +42,7 @@ def test_qclaw_quota_is_credit_not_token_cap(qclaw_enabled):
 
 def test_qclaw_in_default_registry(monkeypatch):
     monkeypatch.delenv("CB_GATEWAY_PROVIDERS", raising=False)
-    assert providers.enabled_provider_ids() == ["workbuddy", "qclaw", "qwenwork"]
+    assert providers.enabled_provider_ids() == ["workbuddy", "qclaw", "qwenwork", "traework"]
     assert providers.get_provider("qclaw") is not None
     assert "qclaw" in providers._LOADED
 

--- a/tests/test_qwenwork.py
+++ b/tests/test_qwenwork.py
@@ -34,7 +34,7 @@ def qwen_enabled(monkeypatch):
 
 def test_qwenwork_in_default_registry(monkeypatch):
     monkeypatch.delenv("CB_GATEWAY_PROVIDERS", raising=False)
-    assert providers.enabled_provider_ids() == ["workbuddy", "qclaw", "qwenwork"]
+    assert providers.enabled_provider_ids() == ["workbuddy", "qclaw", "qwenwork", "traework"]
     assert providers.get_provider("qwenwork") is not None
     assert "qwenwork" in providers._LOADED
 

--- a/tests/test_traework.py
+++ b/tests/test_traework.py
@@ -1,0 +1,124 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import credential_crypto
+import database as db
+import providers
+import router
+from providers.protocol import UnknownModel
+from providers.traework.chat import extract_assistant_text, translate_model
+from providers.traework.crypto import decrypt_tc_b64
+from providers.traework.store import parse_credentials, traework_auth_dirs
+
+
+@pytest.fixture()
+def isolated_db(tmp_path, monkeypatch):
+    path = tmp_path / "gateway.db"
+    monkeypatch.setattr(db, "DB_PATH", path)
+    monkeypatch.setenv("CB_GATEWAY_MASTER_KEY", "pytest-master-key")
+    credential_crypto.reset_cache()
+    db.init_db()
+    yield path
+    credential_crypto.reset_cache()
+
+
+@pytest.fixture()
+def traework_enabled(monkeypatch):
+    monkeypatch.setenv("CB_GATEWAY_PROVIDERS", "workbuddy,traework")
+    yield
+    monkeypatch.delenv("CB_GATEWAY_PROVIDERS", raising=False)
+
+
+def test_traework_in_default_registry(monkeypatch):
+    monkeypatch.delenv("CB_GATEWAY_PROVIDERS", raising=False)
+    assert providers.enabled_provider_ids() == ["workbuddy", "qclaw", "qwenwork", "traework"]
+    assert providers.get_provider("traework") is not None
+    assert "traework" in providers._LOADED
+
+
+def test_parse_credentials_official_shape():
+    parsed = parse_credentials(
+        {
+            "token": "jwt-access",
+            "refreshToken": "rt-1",
+            "userId": "3577",
+            "expiredAt": "2026-09-09T08:55:19.325Z",
+            "host": "https://api.trae.cn",
+            "account": {"username": "书虫"},
+            "device_id": "3446",
+        }
+    )
+    assert parsed["provider"] == "traework"
+    assert parsed["access_token"] == "jwt-access"
+    assert parsed["refresh_token"] == "rt-1"
+    assert parsed["uid"] == "3577"
+    assert parsed["extra"]["device_id"] == "3446"
+    assert parsed["expires_at"] > 10_000_000_000
+
+
+def test_parse_credentials_requires_token():
+    with pytest.raises(ValueError):
+        parse_credentials({"account": {"username": "x"}})
+
+
+def test_bind_traework_when_enabled(traework_enabled):
+    bound = router.bind({"model": "auto"}, {"default_channel": "traework"})
+    assert bound.channel == "traework"
+    assert bound.inner == "auto"
+    bound = router.bind({"model": "traework/qwen-3.7-plus"}, {"default_channel": "traework"})
+    assert bound.inner == "qwen-3.7-plus"
+    with pytest.raises(UnknownModel):
+        router.bind({"model": "glm-5.2"}, {"default_channel": "traework"})
+
+
+def test_translate_auto():
+    assert translate_model("auto") == "qwen-3.7-plus"
+
+
+def test_extract_assistant_text_from_task():
+    items = [
+        {"role": "user", "content": "[]"},
+        {
+            "role": "assistant",
+            "message_type": "task",
+            "content": json.dumps(
+                {
+                    "task_id": "t1",
+                    "messages": [
+                        {"type": "text", "text_content": "pong"},
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+        },
+    ]
+    assert extract_assistant_text(items) == "pong"
+
+
+def test_traework_sources_do_not_touch_workbuddy_stack():
+    root = Path(__file__).resolve().parents[1] / "providers" / "traework"
+    for path in root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        assert "copilot.tencent.com" not in text
+        assert "import fingerprint" not in text
+        assert "from fingerprint" not in text
+        assert "X-IDE-Type" not in text
+
+
+def test_traework_auth_dirs_ignore_workbuddy_cb_auth_dir(monkeypatch, tmp_path):
+    tdir = tmp_path / "trae-auth"
+    tdir.mkdir()
+    wb = tmp_path / "workbuddy-auth"
+    wb.mkdir()
+    monkeypatch.setenv("CB_TRAEWORK_AUTH_DIR", str(tdir))
+    monkeypatch.setenv("CB_AUTH_DIR", str(wb))
+    dirs = [path.resolve() for path in traework_auth_dirs()]
+    assert tdir.resolve() in dirs
+    assert wb.resolve() not in dirs
+
+
+def test_decrypt_tc_roundtrip_rejects_garbage():
+    with pytest.raises(Exception):
+        decrypt_tc_b64("not-base64-$$$")

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.0.1"
+VERSION = "2.1.0"

--- a/web/index.html
+++ b/web/index.html
@@ -388,7 +388,7 @@ createApp({
   template:`
   <div class="layout">
     <header class="topbar">
-      <div class="brand-block"><div class="brand-symbol">B2</div><div class="brand-copy"><div class="brand-title">Buddy 2 API</div><div class="brand-meta">Local model gateway · v2.0.1</div></div></div>
+      <div class="brand-block"><div class="brand-symbol">B2</div><div class="brand-copy"><div class="brand-title">Buddy 2 API</div><div class="brand-meta">Local model gateway · v2.1.0</div></div></div>
       <nav class="topnav"><div v-for="n in nav" :key="n.k" class="nav-item" :class="{on:page===n.k}" @click="go(n.k)" v-html="n.i+'<span>'+n.l+'</span>'"></div></nav>
       <div class="top-actions">
         <button class="refresh-cta" @click="hardRefresh"><span v-html="I.refresh"></span><span>刷新</span></button>
@@ -601,7 +601,7 @@ createApp({
   </template>
 </div>`
 }).component('accs',{props:['token','toast'],setup(p){
-  const l=ref([]),ld=ref(true),sa=ref(false),ai=ref(''),nm=ref(''),disc=ref(null),dl=ref(false),scanning=ref(false),adding=ref(false),authPath=ref(''),test=ref(null),claim=ref(null),pkg=ref(null),tl=ref(0),claimingAll=ref(false),officialRefreshing=ref(false),checkins=ref({}),checkinSummary=ref(null),checkinLoading=ref(false),busy=ref({}),discChannel=ref('workbuddy'),channels=ref([{id:'workbuddy',display_name:'WorkBuddy'},{id:'qclaw',display_name:'QClaw'},{id:'qwenwork',display_name:'QwenWork / 千问办公'}]);
+  const l=ref([]),ld=ref(true),sa=ref(false),ai=ref(''),nm=ref(''),disc=ref(null),dl=ref(false),scanning=ref(false),adding=ref(false),authPath=ref(''),test=ref(null),claim=ref(null),pkg=ref(null),tl=ref(0),claimingAll=ref(false),officialRefreshing=ref(false),checkins=ref({}),checkinSummary=ref(null),checkinLoading=ref(false),busy=ref({}),discChannel=ref('workbuddy'),channels=ref([{id:'workbuddy',display_name:'WorkBuddy'},{id:'qclaw',display_name:'QClaw'},{id:'qwenwork',display_name:'QwenWork / 千问办公'},{id:'traework',display_name:'TraeWork'}]);
   const filters=reactive({q:'',status:'all',claim:'all',sort:'priority'});
   function hydrate(a){return {...a,_weight:a.weight||1,_priority:a.priority||0,_creditSnapshot:a.credit_snapshot||a.credit_limit||0,_baseWeight:a.weight||1,_basePriority:a.priority||0,_baseCreditSnapshot:a.credit_snapshot||a.credit_limit||0}}
   function dirty(a){return Number(a._weight||1)!==Number(a._baseWeight||1)||Number(a._priority||0)!==Number(a._basePriority||0)||Number(a._creditSnapshot||0)!==Number(a._baseCreditSnapshot||0)}
@@ -734,7 +734,7 @@ createApp({
   <div class="ov" v-if="sa" @click.self="sa=false"><div class="modal"><div class="modal-h"><h3>高级手动添加</h3><button class="x" @click="sa=false">&times;</button></div><div class="modal-b"><div class="field"><label>名称</label><input v-model="nm" placeholder="可选"/></div><div class="field"><label>Auth JSON</label><textarea v-model="ai" placeholder="粘贴 .info 文件内容"></textarea><div class="hint">只有自动检测失败时才需要手动粘贴完整 JSON。</div></div></div><div class="modal-f"><button class="btn" @click="sa=false" :disabled="adding">取消</button><button class="btn pri" @click="add" :disabled="adding">{{adding?'添加中':'添加'}}</button></div></div></div>
 </div>`
 }).component('keys',{props:['token','toast'],setup(p){
-  const l=ref([]),ld=ref(true),sa=ref(false),f=reactive({name:'',models:'',limit:null,preset:'custom',channel:'workbuddy'}),res=ref(''),saving=ref(false),copied=ref(false),busy=ref({}),shown=ref({}),codexResult=ref(null),codexBusy=ref(false),channels=ref([{id:'workbuddy',display_name:'WorkBuddy'},{id:'qclaw',display_name:'QClaw'},{id:'qwenwork',display_name:'QwenWork / 千问办公'}]);
+  const l=ref([]),ld=ref(true),sa=ref(false),f=reactive({name:'',models:'',limit:null,preset:'custom',channel:'workbuddy'}),res=ref(''),saving=ref(false),copied=ref(false),busy=ref({}),shown=ref({}),codexResult=ref(null),codexBusy=ref(false),channels=ref([{id:'workbuddy',display_name:'WorkBuddy'},{id:'qclaw',display_name:'QClaw'},{id:'qwenwork',display_name:'QwenWork / 千问办公'},{id:'traework',display_name:'TraeWork'}]);
   const clientTypes=[
     {k:'custom',name:'默认',icon:'⚙'},
     {k:'codex',name:'Codex',icon:'◉'},


### PR DESCRIPTION
Add TraeWork as a fourth default channel. Import official TRAE SOLO CN storage.json, check-in and credit balance, chat via Work sessions with auto mapping to qwen-3.7-plus. Docker still cannot scan the official files unless they were imported into ./data/buddy2api.db on Windows. Includes docs/releases/v2.1.0.md.