### PR TITLE
release: Buddy2api 2.1.4 cryptography 50.0.1 security bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > 把本机已经登录的消费级 AI 客户端，接成 OpenAI 兼容接口，给 Codex、OpenCode、Cherry Studio、NextChat 等用。默认打开 Work Buddy / CodeBuddy、QClaw、千问办公（QwenWork）、TraeWork 四个通道；管理页下拉选其中一个。一次请求只走一个通道。
 
-当前版本 **2.1.3**。这个项目只适合本机自用，不要公开部署，也不要把登录凭据、API Key、数据库文件发给别人。
+当前版本 **2.1.4**。这个项目只适合本机自用，不要公开部署，也不要把登录凭据、API Key、数据库文件发给别人。
 
 ## 这是什么？
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 
 > Local consumer AI clients → one OpenAI-compatible API for Codex, OpenCode, Cherry Studio, NextChat, and similar agents. Work Buddy / CodeBuddy, QClaw, QwenWork, and TraeWork are on by default; pick one in the UI dropdown. Each request stays on one channel.
 
-Release **2.1.3**. Local use only. Do not expose this on the public internet, and do not share credentials, API keys, or the database.
+Release **2.1.4**. Local use only. Do not expose this on the public internet, and do not share credentials, API keys, or the database.
 
 ## What is this?
 

--- a/docs/releases/v2.1.4.md
+++ b/docs/releases/v2.1.4.md
@@ -1,0 +1,24 @@
+# Buddy2api v2.1.4
+
+发布日期：2026-09-07
+
+处理 GitHub 安全告警：升级 `cryptography`，并说明 QClaw 微信 App ID 是公开客户端标识。
+
+## 依赖
+
+- `cryptography` 从 49.0.0 升到 50.0.1，覆盖 CVE-2026-69247（PKCS#7 EnvelopedData 解密的 Bleichenbacher oracle）。
+- 本仓库只用 Fernet、AES、RSA 和 EC，不调用受影响的 `pkcs7_decrypt_*` 接口。
+
+## QClaw 微信 App ID
+
+- `providers/qclaw/constants.py` 里的 `WX_APP_ID` 来自官方 QClaw 客户端，会出现在微信扫码登录 URL 里，不是密钥。
+- GitHub Secret scanning 会把它当成腾讯微信 API App ID；这是误报，已按 false positive 关闭。
+
+## 升级说明
+
+- 无数据库迁移。
+- Docker 用户需要重新构建镜像并重启服务。
+
+## 验证
+
+- 完整测试集：`245 passed`。

--- a/providers/qclaw/constants.py
+++ b/providers/qclaw/constants.py
@@ -9,6 +9,7 @@ DISPLAY_NAME = "QClaw"
 JPRX_GATEWAY = "https://jprx.m.qq.com"
 AIZONE_BASE = "https://mmgrcalltoken.3g.qq.com/aizone/v1"
 WX_LOGIN_REDIRECT = "https://security.guanjia.qq.com/login"
+# Official QClaw WeChat Open Platform appid (public OAuth client id, not a secret).
 WX_APP_ID = "wx9d11056dd75b7240"
 WX_QRCONNECT = "https://open.weixin.qq.com/connect/qrconnect"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==49.0.0
+cryptography==50.0.1
 fastapi==0.141.1
 httpx==0.28.1
 uvicorn[standard]==0.52.0

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.1.3"
+VERSION = "2.1.4"

--- a/web/index.html
+++ b/web/index.html
@@ -388,7 +388,7 @@ createApp({
   template:`
   <div class="layout">
     <header class="topbar">
-      <div class="brand-block"><div class="brand-symbol">B2</div><div class="brand-copy"><div class="brand-title">Buddy 2 API</div><div class="brand-meta">Local model gateway · v2.1.3</div></div></div>
+      <div class="brand-block"><div class="brand-symbol">B2</div><div class="brand-copy"><div class="brand-title">Buddy 2 API</div><div class="brand-meta">Local model gateway · v2.1.4</div></div></div>
       <nav class="topnav"><div v-for="n in nav" :key="n.k" class="nav-item" :class="{on:page===n.k}" @click="go(n.k)" v-html="n.i+'<span>'+n.l+'</span>'"></div></nav>
       <div class="top-actions">
         <button class="refresh-cta" @click="hardRefresh"><span v-html="I.refresh"></span><span>刷新</span></button>


### PR DESCRIPTION
## Change

Clear the three GitHub security alerts for 2.1.4.

- Pin `cryptography` to 50.0.1 so CVE-2026-69247 (PKCS#7 EnvelopedData Bleichenbacher oracle) is patched. `requirements-dev.txt` already includes `requirements.txt`.
- Document that the QClaw `WX_APP_ID` is the official public WeChat Open Platform client id, not a secret. The Secret scanning alert was closed as a false positive.
- Version 2.1.4 with `docs/releases/v2.1.4.md`.

## Validation

- [x] I ran the repository's documented local checks.
- [x] I did not add credentials, databases, private account data, or runtime output.
- [x] I reviewed the changed-file list.
- [x] I will wait for every required CI check before merging.
- [x] I did not create or move a release tag in this pull request.

- [x] `python -m compileall -q .`
- [x] `python -m pytest -q` (245 passed)
- [ ] CI test suite green
- [ ] After merge, run Create release with `v2.1.4`